### PR TITLE
Update cli_swap to fix log usage + update aligner to fix bad char

### DIFF
--- a/cli_swap.py
+++ b/cli_swap.py
@@ -29,12 +29,13 @@ parser.add_argument('file_name', type=str, help='Name of the tiled level XML to 
 parser.add_argument('--v', type=int, choices=[0, 1, 2], default=1, help='Verbosity level: 0 = silent. 2 = verbose')
 args = parser.parse_args()
 
+log.SetVerbosityLevel(args.v)
+log.Info(f'Running cli_swap on LEVEL {args.file_name}...')
+
 # Use a playdo to read/process the XML
 playdo = play.LevelPlayDo(file_utils.GetFullLevelPath(args.file_name))
 
 # Perform the matching - mold the playdo
-log.SetVerbosityLevel(args.v)
-log.Info(f'Running cli_swap on LEVEL {args.file_name}...')
 result = tile_swapper.Swap(playdo)
 
 # Flush changes to File!

--- a/logic/standalone/aligner.py
+++ b/logic/standalone/aligner.py
@@ -13,8 +13,8 @@ import logic.common.tiled_utils as tiled_utils
 '''Variables'''
 
 # For logging
-CHAR_TRUE  = "  ○ "
-CHAR_FALSE = "  ☓ "
+CHAR_TRUE  = "  o "
+CHAR_FALSE = "  X "
 
 
 


### PR DESCRIPTION
log module was used incorrectly resulting in double prints. That problem is now fixed.

aligner used a strange character not compatible with windows, those other characters are now fixed