### PR TITLE
cli_find.py tool added

### DIFF
--- a/cli_find.py
+++ b/cli_find.py
@@ -1,0 +1,78 @@
+'''
+Command-Line Tool to search all levels for a tile ID (+ its 7 other permutations)
+
+This is useful for when we need references and would like to know where a tile
+has been used. Also good for when we suspect a tile ID has become obsoleted and
+would like to confirm that no levels are using it.
+
+USAGE EXAMPLE:
+	python cli_search.py 657    # where 657 is a number ID assigned by TILED
+'''
+
+import argparse
+import logic.common.file_utils as file_utils
+import logic.common.tiled_utils as tiled_utils
+import logic.finder.tile_finder as tile_finder
+import logic.common.log_utils as log
+
+
+#--------------------------------------------------#
+'''Main'''
+
+tool_description = 'Searches all levels for usecases of a tile ID'
+arg_desc_tile_id = 'ID of the tile we wish to search'
+arg_desc_prefix = 'Narrows the search selection requiring files match a prefix. For Ex: "--prefix=f" targets the stomach area'
+arg_desc_verbosity = 'Controls the amount of information displayed to screen. 0 = nearly silent, 2 = verbose'
+
+
+def main():
+    # Use argparse to get the filename & other optional arguments from the command line
+    parser = argparse.ArgumentParser(description=tool_description)
+    parser.add_argument('tile_id', type=int, help=arg_desc_tile_id)
+    parser.add_argument('--prefix', type=str, default=None, help=arg_desc_prefix)
+    parser.add_argument('--v', type=int, choices=[0, 1, 2], default=0, help=arg_desc_verbosity)
+    args = parser.parse_args()
+
+    log.SetVerbosityLevel(args.v)
+    log.Must(f'Running cli_find on TILE ID {args.tile_id} ...')
+    
+    true_tile_id = args.tile_id + 1 # TILE's funny offset thing
+    tiles_to_search = tiled_utils.GetTileIdPermutations(true_tile_id)
+    files_to_search = file_utils.GetAllLevelFiles()
+    
+    # prune the list of files to search if "prefix" is specified
+    if args.prefix is not None:
+        log.Info(f"Narrowing search to select prefix '{args.prefix}'")
+        files_to_search = [fn for fn in files_to_search if file_utils.StripFilename(fn).startswith(args.prefix)]
+        
+    log.Must(f"Preparing to search {len(files_to_search)} files...")
+    
+    files_w_errors = []     # List of files that could not be searched, likely due to using wrong encoding
+    files_w_matches = {}    # dict mapping file_name to another dict of {tile_layer_name : coordinates}
+                            # In other words: {file_name : {tile_layer_name : [(x1,y1), (x2, y2), ...]}
+    for num, filename in enumerate(files_to_search):
+        search_results = tile_finder.SearchFileForTileIds(filename, tiles_to_search)
+        if search_results:
+            files_w_matches[file_utils.StripFilename(filename)] = search_results
+        elif search_results is None:
+            files_w_errors.append(filename)
+    
+    if files_w_errors:
+        log.Info(f"\nWARNING: The below {len(files_w_errors)} files were unsearchable! Likely do to their encoding")
+        for erred_file in files_w_errors:
+            log.Info(f" - {file_utils.StripFilename(erred_file)}")
+            
+    if files_w_matches:
+        log.Must(f"\n\nSUCCESS! TILE ID {args.tile_id} was discovered in {len(files_w_matches)} files...\n")
+        for filename, search_results in files_w_matches.items():
+            log.Must(f"    {filename}.xml ".ljust(50, '-'))
+            log.Must(tile_finder.FormatSearchResult(search_results))
+    else:
+        log.Must(f"\nNOT FOUND! TILE ID {args.tile_id} was not used in any files...")
+    
+    log.Must("\n\ncli_find concluded!")
+
+
+#--------------------------------------------------#
+
+main()

--- a/cli_permutate.py
+++ b/cli_permutate.py
@@ -1,7 +1,16 @@
-""" Command-Line Tool to <FILL IN>
+'''
+Command-Line Tool to permute a pattern XML file to add the 7 other variants
 
-    USAGE: <FILL IN>
-"""
+    Say we wish to create a new skell reef pattern xml to be added to cli_collide tool. We create 
+    a new pattern file XML, add a tile layer, then add an object layer. That allows us to match one
+    orientation. However, the skell reef can be flipped and rotated for a total of 8 different
+    orientations. To save on the tedium of creating the 7 other orientations manally, we can use 
+    cli_permutate. It will create the 7 other orientations. The 7 generated tile layers will be 
+    flipped and rotated. Object layers will have the 'angle' and 'flipped' flags already added
+
+USAGE EXAMPLE:
+	python cli_permutate.py reef7 # reef7.xml has been added as an example
+'''
 
 import os
 import argparse

--- a/input/patterns/reef7.xml
+++ b/input/patterns/reef7.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.5" tiledversion="1.6.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="4" height="4" tilewidth="16" tileheight="16" infinite="0" nextlayerid="86" nextobjectid="672">
+ <tileset firstgid="1" source="../gfx/StarToolsTileset.tsx"/>
+ <layer id="46" name="1" width="4" height="4">
+  <data encoding="base64" compression="zlib">
+   eAFjYMAEjEyoYiA+shgyHwABkgAQ
+  </data>
+ </layer>
+ <objectgroup id="71" name="1">
+  <object id="661" name="relic_block" type="rare" x="16" y="32" width="32" height="32">
+   <properties>
+    <property name="_sort" value="fg_tiles,-1"/>
+    <property name="_type" value="REEF_1"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/logic/common/level_playdo.py
+++ b/logic/common/level_playdo.py
@@ -38,13 +38,13 @@ class LevelPlayDo():
         self.tile_width = int(self.level_root.get('tilewidth'))
         self.tile_height = int(self.level_root.get('tileheight'))
         
-        # Map for tile_layer_name to a tiles2d (A 2d array of tile IDs). This is created & cached w/ GetTilemapAs2DList()
-        self._2D_tiles_map = {}
+        # Map for tile_layer_name to a tiles2d (A 2d array of tile IDs). This is created & cached w/ GetTiles2d()
+        self._tiles2d_map = {}
         
-        # Map for tile_layer_name to a Hashset (for quick checking tile matches). This is created & cached w/  GetTilemapAs2DList()
-        self._2D_tiles_hash = {}
+        # Map for tile_layer_name to a Hashset (for quick checking tile matches). This is created & cached w/  GetTiles2d()
+        self._tiles2d_hash = {}
         
-        log.Info(f"-- level_playdo.py : initialized {file_name} ...")
+        log.Extra(f"-- level_playdo.py : initialized {file_name} ...")
 
 
     def GetAllTileLayerNames(self):
@@ -62,35 +62,39 @@ class LevelPlayDo():
         return tile_layer_names
         
 
-    def GetTiles2d(self, tile_layer_name):
+    def GetTiles2d(self, tile_layer_name, ignore_dupe_warnings = False):
         '''Retrieves Tiles2d by name (2D array of Tile Ids).
         
         tile_layer_name - the name of the tile layer in the LEVEL xml that we want to retrieve.
-        If 'NONE' is provided for input tile_layer_name, then retrieves the first Tiles2D found
+        ignore_dupe_warnings - technically, it's possible for multiple tile layers in a level XML
+        to share the same name. In such cases, GetTiles2d returns the Tiles2D data of the 1st layer
+        with matching name and will inform the client that duplicate layers exist. It's possible
+        to suppress those warnings by setting this flag to true
         
-        Returns 'Tiles2d'. Tiles2d presents the data in an easily readable (already decoded) and
+        Returns 'Tiles2d'. Tiles2d presents the data in an already decoded, easily readable and
         editable format. Apply changes to the Tiles2d and write them back using SetTiles2d()
         '''
-        if tile_layer_name in self._2D_tiles_map:
-            return self._2D_tiles_map[tile_layer_name]
+        if tile_layer_name in self._tiles2d_map:
+            return self._tiles2d_map[tile_layer_name]
         
-        for layer in self.level_root.findall('layer'):
-            if tile_layer_name is None or layer.get('name') == tile_layer_name:
-                if tile_layer_name is None:
-                    tile_layer_name = layer.get('name')
-                data = layer.find('data').text.strip()
-                tile_2d_map = tiled_utils.DecodeIntoTiles2d(data, self.map_width)
-                self._2D_tiles_map[tile_layer_name] = tile_2d_map
+        tiles2d = None
+        for layer in self.level_root.findall('.//layer'):
+            if layer.get('name') == tile_layer_name:
+                self._ProcessLayer(layer, tile_layer_name)
+                if tiles2d is None:
+                    tiles2d = self._tiles2d_map[tile_layer_name]
+                    if ignore_dupe_warnings: return tiles2d
+                else:
+                    log.Extra(f"level_playdo.py : GetTiles2d was called for a layer '{tile_layer_name}'" + 
+                        ", but multiple tile layers with that name exists!")
                 
-                # Create the cache for quick-checking matches in the future
-                self._2D_tiles_hash[tile_layer_name] = set()
-                for tile_row in tile_2d_map:
-                    self._2D_tiles_hash[tile_layer_name].update(tile_row)
-                
-                return tile_2d_map
         
-        return None
-
+        if tiles2d is None:
+            log.Extra(f"level_playdo.py : GetTiles2d was called for a layer '{tile_layer_name}' " + 
+                "which did not exist!")
+        
+        return tiles2d
+        
 
     def SetTiles2d(self, tile_layer_name, new_tiles2d):
         '''Overwrites a LEVEL XML's tile layer with new data - usually after edits have been made
@@ -112,10 +116,10 @@ class LevelPlayDo():
 
     def GetTilesHashSet(self, tile_layer_name):
         #log.Info(f"-- level_playdo.py : GetTilemapAsHashSet {tile_layer_name}")
-        if tile_layer_name not in self._2D_tiles_hash:
-            raise Exception(f"level_playdo.py : tile_layer hashset '{tile_layer_name}' was requested, but does not exist! " +
-                "Call GetTilemapAs2DList() first - that will force its creation.")
-        return self._2D_tiles_hash[tile_layer_name]
+        if tile_layer_name not in self._tiles2d_hash:
+            raise Exception(f"level_playdo.py : tile_layer hashset '{tile_layer_name}' was requested," + 
+            " but does not exist! Call GetTiles2d() first - that will force its creation.")
+        return self._tiles2d_hash[tile_layer_name]
 
 
 
@@ -198,14 +202,49 @@ class LevelPlayDo():
                 elem.set('value', elem.get('value').replace(target_text, new_number_string))
 
 
-
     def Write(self):
         '''Stamps the Playdo back into an XML file and writes to disk'''
         log.Info(f"-- level_playdo.py : flushing changes...")
         self.my_xml_tree.write(self.full_file_name)
 
 
+    def PreCalculateInternalTileData(self):
+        '''Iterate through all the tile layers and prefill '_tiles2d_map' & '_tiles2d_hash' data
+        and then returns them.
         
+        Normally, these internal data structures are constructed as needed via calls to GetTiles2d()
+        However, GetTiles2d has some blindspots since level names need not be unique. For example,
+        if there were 2 tile layers named 'fg_raw', the first fg_raw layer would get processed, and
+        it's data would fill _tiles2d_map and _tiles2d_hash. The 2nd fg_raw layer would not be
+        reachable and ignored.
+        
+        Using PreCalculateInternalTileData ensures that the 2nd fg_raw layer will at LEAST be able
+        to be processed and inputted into _tiles2d_hash. This way, when it comes to searches, we
+        can at least confirm with 100% accuracy something exists (instead of missing it entirely)
+        
+        Returns two maps: '_tiles2d_map' & '_tiles2d_hash'
+        '''
+        for tile_layer in self.level_root.findall(".//layer"):
+            tile_layer_name = tile_layer.get('name')
+            if tile_layer_name is None:
+                tile_layer_name = 'unnamed_tile_layer'
+            self._ProcessLayer(tile_layer, tile_layer_name)
+        
+        return self._tiles2d_map, self._tiles2d_hash
+    
+    
+    def _ProcessLayer(self, layer, tile_layer_name):
+        '''Process a tile layer element tree object, and fill our internal data structures for future ops'''
+        
+        # Create and store the Tile2d map
+        data = layer.find('data').text.strip()
+        tile_2d_map = tiled_utils.DecodeIntoTiles2d(data, self.map_width)
+        self._tiles2d_map[tile_layer_name] = tile_2d_map
+        
+        # Also maintain hash of the Tile Ids to facililate quicker lookups in the future
+        self._tiles2d_hash[tile_layer_name] = set()
+        for tile_row in tile_2d_map:
+            self._tiles2d_hash[tile_layer_name].update(tile_row)
 #--------------------------------------------------#
 '''...'''        
 

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -131,7 +131,6 @@ def FlipTileId(tile_id):
     return tile_id ^ mask
 
 
-
 def RotateTileId(tile_id):
     '''Rotates one tiles 90˚ clockwise (pressing [z] in Tiled), e.g. 1 -> 2684354563'''
 
@@ -147,6 +146,7 @@ def RotateTileId(tile_id):
 
     return tile_id
 
+
 # Maps the top 3 bit transformation patterns for TILED rotations
 _ROTATE_BIT_MAP = {
     0b000: 0b101,
@@ -159,7 +159,14 @@ _ROTATE_BIT_MAP = {
     0b001: 0b100
 }
 
-
+def GetTileIdPermutations(tile_id):
+    '''Processes tile id & returns a list of 8 tile ids (all of the possible orientations from flipping & rotating)'''
+    tile_id_list = [tile_id, FlipTileId(tile_id)]
+    for _ in range(3):
+        tile_id = RotateTileId(tile_id)
+        tile_id_list.append(tile_id)
+        tile_id_list.append(FlipTileId(tile_id))
+    return tile_id_list
 
 #--------------------------------------------------#
 '''Object Properties'''

--- a/logic/finder/tile_finder.py
+++ b/logic/finder/tile_finder.py
@@ -1,0 +1,92 @@
+'''
+Module for searching tile IDs in a level
+
+This is useful for when we need references and would like to know where a tile
+has been used. Also good for when we suspect a tile ID has become obsoleted and
+would like to confirm that no other levels are using it.
+
+USAGE EXAMPLE:
+    import logic.finder.tile_finder as tile_finder
+    
+    file_name = "j24.xml"
+    tile_id = 657
+    tile_finder.SearchFile(file_name, tile_id)
+'''
+
+import logic.common.file_utils as file_utils
+import logic.common.level_playdo as play
+import logic.common.log_utils as log
+
+def SearchFileForTileIds(filename, tiles_to_search):
+    '''Searches a File for select TILE IDs
+      
+    filename - the name of the file we want to search
+    tiles_to_search - list of tile IDs we want to search. Usually this is a list of 8 tile IDs where
+        the 1st entry is the tile ID & the other 7 are its permutations after flipping & rotations
+    
+    Returns a dictionary mapping tile_layer_name to a list of coordinates where matches were found.
+    Returns an empty dictionary if no matches were found.
+    Returns None if a file erred out and could not be searched
+    '''
+    try:
+        playdo = play.LevelPlayDo(filename)
+        tiles2d_map, tiles2d_hash = playdo.PreCalculateInternalTileData()
+    except Exception as e:
+        return None
+        
+    layers_containing_target = []
+    search_results = {} # dict of 'layer_name' to list of coordinate tuples
+    for tile_layer_name in tiles2d_hash.keys():
+        playdo.GetTiles2d(tile_layer_name)
+        tiles_hash = playdo.GetTilesHashSet(tile_layer_name)
+        for tile_id in tiles_to_search:
+            if tile_id in tiles_hash:
+                _RefineSearchResult(tile_id, tile_layer_name, tiles2d_map, search_results)
+                layers_containing_target.append(tile_layer_name)
+
+    return search_results
+
+def _RefineSearchResult(search_tile_id, tile_layer_name, tiles2d_map, search_result):
+    '''
+    Refines a search result so we can attach the location of a match to the layer it was 
+    found. We use this when we have a hit in the tiles hash cache, and want to refine 
+    the result to indicate where in the tiles specifically a tile was used.
+      
+    search_tile_id - the tile id we are searching
+    tile_layer_name - the layer name we know it to exist in
+    tiles2d_map - map of tile_layer_name to tiles2d data - obtained from playdo
+    search_result - dictionary of tile_layer_name to a list of coordinates. _RefineSearchResult
+        doesn't return a value, but it will update this search_result structure
+    '''
+    containing_tiles2d = tiles2d_map[tile_layer_name]
+    
+    if tile_layer_name not in search_result:
+        search_result[tile_layer_name] = []
+        
+    for row, tile_row in enumerate(containing_tiles2d):
+        for col, tile_id in enumerate(tile_row):
+            if search_tile_id == tile_id:
+                if tile_layer_name in search_result:
+                    search_result[tile_layer_name].append((col, row))
+                    
+def FormatSearchResult(search_results):
+    '''Formats the search_result returned from SearchFile() into a pretty printable string'''    
+    master_string = ""
+    for layername, coords in search_results.items():
+        # Adjust the layer name to 16 characters
+        layer_string = None
+        if len(layername) <= 16: layer_string = f"        {layername.ljust(16)}:"
+        else: layer_string = f"      {layername[:14]}..:"
+        
+        # Add the coordinates with a space inbetween
+        for coord in coords:
+            layer_string += f" {coord} "
+        
+        # Crop length of the coordinates to keep to one line in case it's too long
+        if len(layer_string) > 100:
+            layer_string = layer_string[:97] + "..."
+        
+        # Add a newline to delineate different tile layers
+        master_string += (layer_string + "\n")
+    return master_string
+

--- a/logic/pattern/pattern_permuter.py
+++ b/logic/pattern/pattern_permuter.py
@@ -10,7 +10,7 @@ def CreatePermutationsOfPattern(playdo):
     _ValidatePattern(playdo)
     
     # Fetch the singular object_group and tiles2d from the file
-    orig_tiles2d = playdo.GetTiles2d(None)
+    orig_tiles2d = _GetAnyTiles2d(playdo)
     orig_object_group = playdo.GetObjectGroup(None, discard_old = False)
     
     # Create 7 copies of the tile layer and object group
@@ -32,6 +32,14 @@ def CreatePermutationsOfPattern(playdo):
         playdo.AddNewTileLayer(new_name, encoded_data_str, '100')
         playdo.DuplicateObjectGroup(orig_object_group, new_name, obj_properties)
             
+
+def _GetAnyTiles2d(playdo):
+    '''Fetches the first tile layer. We do this since we expect there'd be just one tile layer'''
+    all_tile_layer_names = playdo.GetAllTileLayerNames()
+    tile_layer_name = all_tile_layer_names[0]
+    return playdo.GetTiles2d(tile_layer_name)
+
+
 def _GenerateVariants(tiles_2d):
     variants = []
     # first append a flipped version of the original tiles_2d


### PR DESCRIPTION
cli_find.py tool added. This tool allows users to search for usages of a tile id across all level files

Also edited/updated level playdo for more reuse and decomposition
deprecated some behaviors (such as playdo.GetTiles2d returning a friendly result if NONE was the input)