### PR TITLE
Scroll Adder 1.0

### DIFF
--- a/cli_scroll.py
+++ b/cli_scroll.py
@@ -17,11 +17,10 @@ import logic.standalone.scroll_adder as scroll_adder
 '''Variables'''
 # Delete section if unneeded
 
-input_layer = '_scroll'
-output_layer = 'bg_0/fx'
-default_values = (1, 2, 3, 4)
-default_values = (0.1, 0.1, -2, -2)	# scroll_x, scroll_y, add_x, add_y
-default_values = (0, 0, 0, 0)
+input_layer = '_scroll'			# PREFIX of the tilelayer, scroll values specified here
+					# e.g. _scroll, _scroll_0.1, _scroll_0.1_-0.2
+output_layer = '_bg/fx'
+default_values = (0, 0, 0, 0)		# scroll_x, scroll_y, add_x, add_y
 
 
 

--- a/cli_scroll.py
+++ b/cli_scroll.py
@@ -16,10 +16,10 @@ import logic.standalone.scroll_adder as scroll_adder
 #--------------------------------------------------#
 '''Variables'''
 
-input_layer = '_scroll'			# PREFIX of the tilelayer, scroll values specified here
-					# e.g. _scroll, _scroll_0.1, _scroll_0.1_-0.2
+input_layer = '_scroll'            # PREFIX of the tilelayer, scroll values specified here
+                                   # e.g. _scroll, _scroll_0.1, _scroll_0.1_-0.2
 output_layer = '_bg/fx'
-default_values = (0, 0, 0, 0)		# scroll_x, scroll_y, add_x, add_y
+default_values = (0, 0, 0, 0)        # scroll_x, scroll_y, add_x, add_y
 
 
 

--- a/cli_scroll.py
+++ b/cli_scroll.py
@@ -1,8 +1,9 @@
-''' Command-Line Tool for testing features in isolation.
-    Can also be used as template for creating new files
+'''
+Command-Line Tool template when new tools are being created.
+Can also be used to test features in isolation.
     
 USAGE EXAMPLE:
-    python cli_test.py __test --v 0
+    python cli_scroll.py _scroll --v 2
 
 '''
 import argparse
@@ -10,10 +11,17 @@ import logic.common.file_utils as file_utils
 import logic.common.log_utils as log
 import logic.common.level_playdo as play
 import logic.pattern.pattern_matcher as PM
+import logic.standalone.scroll_adder as scroll_adder
 
 #--------------------------------------------------#
 '''Variables'''
 # Delete section if unneeded
+
+input_layer = '_scroll'
+output_layer = 'bg_0/fx'
+default_values = (1, 2, 3, 4)
+default_values = (0.1, 0.1, -2, -2)	# scroll_x, scroll_y, add_x, add_y
+default_values = (0, 0, 0, 0)
 
 
 
@@ -35,11 +43,10 @@ def main():
     log.SetVerbosityLevel(args.v)
 
     # Use a playdo to read/process the XML
-    pattern_root = file_utils.GetPatternRoot()
     playdo = play.LevelPlayDo(file_utils.GetFullLevelPath(args.filename))
 
-    # Main Logic - ...
-#    do_the_thing()
+    # Main Logic
+    scroll_adder.AddScroll(playdo, input_layer, output_layer, default_values)
 
     # Flush changes to File!
     playdo.Write()

--- a/cli_scroll2.py
+++ b/cli_scroll2.py
@@ -1,10 +1,11 @@
 '''
-Command-Line Tool for adding both Default and Custom Properties for scrolling,
-  i.e. Scroll 1 values (add_x, add_y, scroll_x, scroll_y), and Scroll 2 values
+Command-Line Tool for quickly adding Default Properties (Scroll 2) of Tiled tilelayers.
+The values are calculated based on existing Custom Properties created prior (Scroll 1),
+  i.e. add_x, add_y, scroll_x, scroll_y
 
     
 USAGE EXAMPLE:
-    python cli_scroll.py _scroll --v 2
+    python cli_scroll2.py e02 --v 2
 
 '''
 import argparse
@@ -15,11 +16,7 @@ import logic.standalone.scroll_adder as scroll_adder
 
 #--------------------------------------------------#
 '''Variables'''
-
-input_layer = '_scroll'			# PREFIX of the tilelayer, scroll values specified here
-					# e.g. _scroll, _scroll_0.1, _scroll_0.1_-0.2
-output_layer = '_bg/fx'
-default_values = (0, 0, 0, 0)		# scroll_x, scroll_y, add_x, add_y
+# Delete section if unneeded
 
 
 
@@ -40,11 +37,12 @@ def main():
     args = parser.parse_args()
     log.SetVerbosityLevel(args.v)
 
+    # TODO scan through all levels in folder?
     # Use a playdo to read/process the XML
     playdo = play.LevelPlayDo(file_utils.GetFullLevelPath(args.filename))
 
     # Main Logic
-    scroll_adder.AddScroll(playdo, input_layer, output_layer, default_values)
+    scroll_adder.AddScroll2(playdo)
 
     # Flush changes to File!
     playdo.Write()

--- a/logic/common/level_playdo.py
+++ b/logic/common/level_playdo.py
@@ -98,6 +98,18 @@ class LevelPlayDo():
 
 
 
+    def GetTilelayerObject(self, layer_name):
+        '''Retrieve the tilelayer as an object in order to read the properties as well'''
+        # Search using an XPath query so that tile_layers tucked within folders will not be missed
+        for tile_layer in self.level_root.findall(".//layer"):
+            tile_layer_name = tile_layer.get('name')
+            if tile_layer_name == layer_name: return tile_layer
+        return None
+
+
+
+
+
     def GetAllTiles2d(self):
         '''Fetches all graphic tile layers and returns them as a list of Tiles2d'''
         list_tiles2d = []
@@ -278,6 +290,9 @@ class LevelPlayDo():
         self._tiles2d_hash[tile_layer_name] = set()
         for tile_row in tile_2d_map:
             self._tiles2d_hash[tile_layer_name].update(tile_row)
+
+
+
 #--------------------------------------------------#
 '''...'''        
 

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -215,35 +215,35 @@ def GetTileIdPermutations(tile_id):
 '''Tilelayer'''
 
 def MakeTiles2D( tiles2d_template, default_fill = 0 ):
-	'''Return a tiles2d that has the same dimension as the input tiles2D'''
-	map_height = len(tiles2d_template)
-	map_width  = len(tiles2d_template[0])
-	tiles2d_new = [ [default_fill for i in range(map_width)] for j in range(map_height) ]
-	return tiles2d_new
+    '''Return a tiles2d that has the same dimension as the input tiles2D'''
+    map_height = len(tiles2d_template)
+    map_width  = len(tiles2d_template[0])
+    tiles2d_new = [ [default_fill for i in range(map_width)] for j in range(map_height) ]
+    return tiles2d_new
 
 
 
 def AddTilelayer( playdo, layer_name, tiles2d, list_properties = [], list_info = [], is_overwrite = True ):
-	'''
-	Add a tilelayer to playdo by directly inputting a tiles2D
-	If is_overwrite is true, no new layer would be created if one already exists in level
-	Allow adding properties directly, as list of tuples (2 strings), e.g.
-		[ ("Property 1", "Value 1"), ("Property 2", "Value 2") ]
-	'''
+    '''
+    Add a tilelayer to playdo by directly inputting a tiles2D
+    If is_overwrite is true, no new layer would be created if one already exists in level
+    Allow adding properties directly, as list of tuples (2 strings), e.g.
+        [ ("Property 1", "Value 1"), ("Property 2", "Value 2") ]
+    '''
 
-	if playdo.GetTilelayerObject(layer_name) != None and is_overwrite:
-		playdo.SetTiles2d( layer_name, tiles2d )
-	else:
-		playdo.AddNewTileLayer( layer_name, EncodeToTiledFormat(tiles2d) )
-	tilelayer_obj = playdo.GetTilelayerObject(layer_name)
+    if playdo.GetTilelayerObject(layer_name) != None and is_overwrite:
+        playdo.SetTiles2d( layer_name, tiles2d )
+    else:
+        playdo.AddNewTileLayer( layer_name, EncodeToTiledFormat(tiles2d) )
+    tilelayer_obj = playdo.GetTilelayerObject(layer_name)
 
-	# Append "Custom Properties" to layer, e.g. in-game view
-	for property_tuple in list_properties:
-		SetPropertyOnObject(tilelayer_obj, property_tuple[0], property_tuple[1])
+    # Append "Custom Properties" to layer, e.g. in-game view
+    for property_tuple in list_properties:
+        SetPropertyOnObject(tilelayer_obj, property_tuple[0], property_tuple[1])
 
-	# Add additional "Default Properties" to layer, e.g. in-game view
-	for info_tuple in list_info:
-		tilelayer_obj.set( info_tuple[0], info_tuple[1] )
+    # Add additional "Default Properties" to layer, e.g. in-game view
+    for info_tuple in list_info:
+        tilelayer_obj.set( info_tuple[0], info_tuple[1] )
 
 
 

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -3,6 +3,7 @@
 import base64
 import zlib
 import numpy
+import xml.etree.ElementTree as ET
 
 
 
@@ -211,6 +212,40 @@ def GetTileIdPermutations(tile_id):
 
 
 #--------------------------------------------------#
+'''Tilelayer'''
+
+def MakeTiles2D( tiles2d_template, default_fill = 0 ):
+	'''Return a tiles2d that has the same dimension as the input tiles2D'''
+	map_height = len(tiles2d_template)
+	map_width  = len(tiles2d_template[0])
+	tiles2d_new = [ [default_fill for i in range(map_width)] for j in range(map_height) ]
+	return tiles2d_new
+
+
+
+def AddTilelayer( playdo, layer_name, tiles2d, list_properties = [], is_overwrite = True ):
+	'''
+	Add a tilelayer to playdo by directly inputting a tiles2D
+	If is_overwrite is true, no new layer would be created if one already exists in level
+	Allow adding properties directly, as list of tuples (2 strings), e.g.
+		[ ("Property 1", "Value 1"), ("Property 2", "Value 2") ]
+	'''
+
+	if playdo.GetTilelayerObject(layer_name) != None and is_overwrite:
+		playdo.SetTiles2d( layer_name, tiles2d )
+	else:
+		playdo.AddNewTileLayer( layer_name, EncodeToTiledFormat(tiles2d) )
+	tilelayer_obj = playdo.GetTilelayerObject(layer_name)
+
+	# Append properties to new tilelayer`
+	for property_tuple in list_properties:
+		SetPropertyOnObject(tilelayer_obj, property_tuple[0], property_tuple[1])
+
+
+
+
+
+#--------------------------------------------------#
 '''Fetch object property'''
 
 # Currently unused
@@ -273,7 +308,7 @@ def SetPropertyOnObject(tiled_object, property_name, new_value):
         return
 
     # Add new property if it's originally absent in the tiled_obejct
-    ET.SubElement(prop_elem, 'property', attrib={'name': key, 'value': value})
+    ET.SubElement(prop_elem, 'property', attrib={'name': property_name, 'value': new_value})
 
 
 

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -223,7 +223,7 @@ def MakeTiles2D( tiles2d_template, default_fill = 0 ):
 
 
 
-def AddTilelayer( playdo, layer_name, tiles2d, list_properties = [], is_overwrite = True ):
+def AddTilelayer( playdo, layer_name, tiles2d, list_properties = [], list_info = [], is_overwrite = True ):
 	'''
 	Add a tilelayer to playdo by directly inputting a tiles2D
 	If is_overwrite is true, no new layer would be created if one already exists in level
@@ -237,9 +237,13 @@ def AddTilelayer( playdo, layer_name, tiles2d, list_properties = [], is_overwrit
 		playdo.AddNewTileLayer( layer_name, EncodeToTiledFormat(tiles2d) )
 	tilelayer_obj = playdo.GetTilelayerObject(layer_name)
 
-	# Append properties to new tilelayer`
+	# Append "Custom Properties" to layer, e.g. in-game view
 	for property_tuple in list_properties:
 		SetPropertyOnObject(tilelayer_obj, property_tuple[0], property_tuple[1])
+
+	# Add additional "Default Properties" to layer, e.g. in-game view
+	for info_tuple in list_info:
+		tilelayer_obj.set( info_tuple[0], info_tuple[1] )
 
 
 

--- a/logic/standalone/scroll_adder.py
+++ b/logic/standalone/scroll_adder.py
@@ -1,0 +1,120 @@
+'''
+TBA
+
+
+USAGE EXAMPLE:
+	scroll_adder.AddScroll(playdo, input_layer, output_layer, default_values)
+'''
+
+import logic.common.log_utils as log
+import logic.common.tiled_utils as tiled_utils
+
+#--------------------------------------------------#
+'''Variables'''
+
+# Default values for the configurations
+config_add_transparency = True
+config_ = True
+
+DEFAULT_COLOR = 'ffffff/0.7'
+
+
+
+
+#--------------------------------------------------#
+'''Public Functions'''
+
+def AddScroll(playdo, input_layer, output_layer, default_values):
+	'''Main Logic'''
+	log.Info("\nAdjusting tilelayer when added scrolling values...")
+
+	# Fetch the input tilelayer
+	tilelayer_obj = playdo.GetTilelayerObject(input_layer)
+	if tilelayer_obj == None: return
+	tiles2d = playdo.GetTiles2d(input_layer)
+	tiles2d_new = tiled_utils.MakeTiles2D(tiles2d)
+#	tiles2d_new = tiled_utils.CopyXMLObject(tiles2d)	# Technically not an object
+
+	# Register the property values
+	scroll_x, scroll_y, add_x, add_y = default_values
+	scroll_x = ToNum( GetProperty( tilelayer_obj, 'scroll_x', scroll_x ) )
+	scroll_y = ToNum( GetProperty( tilelayer_obj, 'scroll_y', scroll_y ) )
+	add_x = ToNum( GetProperty( tilelayer_obj, 'add_x', add_x ) )
+	add_y = ToNum( GetProperty( tilelayer_obj, 'add_y', add_y ) )
+
+	# Create the list of properties to be added to output tilelayer
+	list_properties = []
+	list_properties.append( ('scroll_x', str(scroll_x)) )
+	list_properties.append( ('scroll_y', str(scroll_y)) )
+	list_properties.append( ('add_x', str(add_x)) )
+	list_properties.append( ('add_y', str(add_y)) )
+	if config_add_transparency:
+		list_properties.append( ('color', DEFAULT_COLOR) )
+
+	# Process tilelayer data (tiles2d)
+	multiplier_x = 1 * ( 1 + scroll_x )
+	multiplier_y = 1 * ( 1 + scroll_y )
+	map_height = len(tiles2d)
+	map_width  = len(tiles2d[0])
+	for i in range(map_height):
+		ref_y = int( i * multiplier_y )
+		if ref_y >= map_height: continue
+		for j in range(map_width):
+			ref_x = int( j * multiplier_x )
+			if ref_x >= map_width: continue
+#			tiles2d_new[new_y][new_x] = 10
+			tiles2d_new[i][j] = tiles2d[ref_y][ref_x]
+#			tiles2d_new[i][j] = 10
+
+	# Create the output tilelayer
+	log.Info(f"  Creating output layer \'{output_layer}\'...")
+	tiled_utils.AddTilelayer( playdo, output_layer, tiles2d_new, list_properties )
+
+	log.Info(f"~~End of All Procedures~~\n")
+
+
+
+
+
+#--------------------------------------------------#
+'''Utility'''
+
+def GetProperty(obj, prop_name, default_value = ''):
+	'''Return the property value from an object, or the default value if there's none'''
+	value = tiled_utils.GetPropertyFromObject( obj, prop_name )
+	if value == '': value = default_value
+	return value
+
+
+
+def ToNum( value ):
+	'''Convert property values to either int or float'''
+	# Return int if decimal places not needed
+	try:
+		if float(value) == int(value): return int(value)
+	except ValueError: None
+
+	# Return float if is a number
+	try:
+		return float(value)
+	except ValueError: None
+
+	# Return string if cannot be converted
+	return value_str
+
+
+
+
+
+#--------------------------------------------------#
+
+
+
+
+
+
+
+
+
+
+# End of File

--- a/logic/standalone/scroll_adder.py
+++ b/logic/standalone/scroll_adder.py
@@ -3,7 +3,7 @@ TBA
 
 
 USAGE EXAMPLE:
-	scroll_adder.AddScroll(playdo, input_layer, output_layer, default_values)
+    scroll_adder.AddScroll(playdo, input_layer, output_layer, default_values)
 '''
 
 import logic.common.log_utils as log
@@ -12,8 +12,8 @@ import logic.common.tiled_utils as tiled_utils
 #--------------------------------------------------#
 '''Variables'''
 
-DEFAULT_COLOR = 'ffffff/1'	# In-Game View
-DEFAULT_OPACITY = '0.4'		# In-Editor View
+DEFAULT_COLOR = 'ffffff/1'    # In-Game View
+DEFAULT_OPACITY = '0.4'        # In-Editor View
 
 # TODO Eventually be setting these in the CLI instead
 # Default values for the configurations
@@ -31,80 +31,80 @@ config_ = True
 '''Scroll 2 very scuffed code'''
 
 def AddScroll2(playdo):
-	'''Main Logic, for Scroll 2, also very rough'''
-	log.Info("\nScanning all tilelayers to check if Scroll2 values need to be added...")
-	count = 0
+    '''Main Logic, for Scroll 2, also very rough'''
+    log.Info("\nScanning all tilelayers to check if Scroll2 values need to be added...")
+    count = 0
 
-	# Get all tilelayer as objects, put into a single list
-	list_all_tilelayer_object = []
-	for layer_name in playdo.GetAllTileLayerNames():
-		list_all_tilelayer_object.append( playdo.GetTilelayerObject(layer_name) )
+    # Get all tilelayer as objects, put into a single list
+    list_all_tilelayer_object = []
+    for layer_name in playdo.GetAllTileLayerNames():
+        list_all_tilelayer_object.append( playdo.GetTilelayerObject(layer_name) )
 
-	# Check if any layer need to add Scroll 2 values
-	#   e.g. has only the old Scroll 1 values
-	log.Info(f"  Scanning {len(list_all_tilelayer_object)} tilelayers...")
-	for obj in list_all_tilelayer_object:
-		properties = obj.find("properties")
-		if properties == None: continue
+    # Check if any layer need to add Scroll 2 values
+    #   e.g. has only the old Scroll 1 values
+    log.Info(f"  Scanning {len(list_all_tilelayer_object)} tilelayers...")
+    for obj in list_all_tilelayer_object:
+        properties = obj.find("properties")
+        if properties == None: continue
 
-		# Check if scroll2 is needed
-		# Cannot use GetPropertyFromObject() because it never returns None
-		has_scroll2 = False
-		add_x, add_y, scroll_x, scroll_y = 0,0,0,0
-		for property in properties:
-			if property.get("name") == "scroll2":
-				has_scroll2 = True
-		if not has_scroll2: continue
+        # Check if scroll2 is needed
+        # Cannot use GetPropertyFromObject() because it never returns None
+        has_scroll2 = False
+        add_x, add_y, scroll_x, scroll_y = 0,0,0,0
+        for property in properties:
+            if property.get("name") == "scroll2":
+                has_scroll2 = True
+        if not has_scroll2: continue
 
-		# Fetch old Scroll 1 values and process
-		add_x = tiled_utils.GetPropertyFromObject(obj, "add_x")
-		add_y = tiled_utils.GetPropertyFromObject(obj, "add_y")
-		scroll_x = tiled_utils.GetPropertyFromObject(obj, "scroll_x")
-		scroll_y = tiled_utils.GetPropertyFromObject(obj, "scroll_y")
+        # Fetch old Scroll 1 values and process
+        add_x = tiled_utils.GetPropertyFromObject(obj, "add_x")
+        add_y = tiled_utils.GetPropertyFromObject(obj, "add_y")
+        scroll_x = tiled_utils.GetPropertyFromObject(obj, "scroll_x")
+        scroll_y = tiled_utils.GetPropertyFromObject(obj, "scroll_y")
 
-		# Set the new Scroll 2 values to layer
-		SetScroll2ToObject( obj, add_x, add_y, scroll_x, scroll_y )
+        # Set the new Scroll 2 values to layer
+        SetScroll2ToObject( obj, add_x, add_y, scroll_x, scroll_y )
 
-	log.Info(f"~~End of All Procedures~~\n")
-	return
+    log.Info(f"~~End of All Procedures~~\n")
+    return
 
 # TODO relocate below
 def SetScroll2ToObject( obj, add_x, add_y, scroll_x, scroll_y ):
-	'''Input the old Scroll 2 values, add the new for Scroll 2 for in-editor view'''
+    '''Input the old Scroll 2 values, add the new for Scroll 2 for in-editor view'''
 
-	# Convert values into float, from either string or None (when no value is specified)
-	add_x = ToNum2(add_x)
-	add_y = ToNum2(add_y)
-	scroll_x = ToNum2(scroll_x)
-	scroll_y = ToNum2(scroll_y)
-	layer_height = ToNum2(obj.get("height"))
+    # Convert values into float, from either string or None (when no value is specified)
+    add_x = ToNum2(add_x)
+    add_y = ToNum2(add_y)
+    scroll_x = ToNum2(scroll_x)
+    scroll_y = ToNum2(scroll_y)
+    layer_height = ToNum2(obj.get("height"))
 
-	# Conversion formula
-	factor_x = 1 - scroll_x
-	factor_y = 1 - scroll_y
-	offset_x = 16 * add_x
-	offset_y = -16 * ( add_y + layer_height * scroll_y )
+    # Conversion formula
+    factor_x = 1 - scroll_x
+    factor_y = 1 - scroll_y
+    offset_x = 16 * add_x
+    offset_y = -16 * ( add_y + layer_height * scroll_y )
 
-	# Set the Scroll2 values
-	obj.set('parallaxx', str(factor_x) )
-	obj.set('parallaxy', str(factor_y) )
-	obj.set('offsetx', str(offset_x) )
-	obj.set('offsety', str(offset_y) )
+    # Set the Scroll2 values
+    obj.set('parallaxx', str(factor_x) )
+    obj.set('parallaxy', str(factor_y) )
+    obj.set('offsetx', str(offset_x) )
+    obj.set('offsety', str(offset_y) )
 
-	# Set backup values
-	#   When level is resized, Tiled may delete any existing Scroll 2 values
-	#   Backing them up in Custom Property allow them to be easily restored later
-	if not config_backup_scroll2: return
-	tiled_utils.SetPropertyOnObject(obj, 'zbackup_parallaxx', str(factor_x))
-	tiled_utils.SetPropertyOnObject(obj, 'zbackup_parallaxy', str(factor_y))
-	tiled_utils.SetPropertyOnObject(obj, 'zbackup_offsetx', str(offset_x))
-	tiled_utils.SetPropertyOnObject(obj, 'zbackup_offsety', str(offset_y))
+    # Set backup values
+    #   When level is resized, Tiled may delete any existing Scroll 2 values
+    #   Backing them up in Custom Property allow them to be easily restored later
+    if not config_backup_scroll2: return
+    tiled_utils.SetPropertyOnObject(obj, 'zbackup_parallaxx', str(factor_x))
+    tiled_utils.SetPropertyOnObject(obj, 'zbackup_parallaxy', str(factor_y))
+    tiled_utils.SetPropertyOnObject(obj, 'zbackup_offsetx', str(offset_x))
+    tiled_utils.SetPropertyOnObject(obj, 'zbackup_offsety', str(offset_y))
 
 # TODO relocate and rename, maybe merge with the other ToNum function?
 def ToNum2(value):
-#	print(value)
-	if value == None: return 0
-	return float(value)
+#    print(value)
+    if value == None: return 0
+    return float(value)
 
 
 
@@ -114,75 +114,75 @@ def ToNum2(value):
 '''Public Functions'''
 
 def AddScroll(playdo, input_prefix, output_layer, default_values):
-	'''Main Logic'''
-	log.Info("\nAdjusting tilelayer when added scrolling values...")
+    '''Main Logic'''
+    log.Info("\nAdjusting tilelayer when added scrolling values...")
 
-	# Detect the correct tilelayer to be processed
-	list_all_layer_name = playdo.GetAllTileLayerNames()
-	applicable_layer_name = None
-	for name in list_all_layer_name:
-		if not name.startswith( input_prefix ): continue
-		applicable_layer_name = name
-		break
-	if applicable_layer_name == None: return
-	log.Info(f"  Layer \"{applicable_layer_name}\" will be processed")
+    # Detect the correct tilelayer to be processed
+    list_all_layer_name = playdo.GetAllTileLayerNames()
+    applicable_layer_name = None
+    for name in list_all_layer_name:
+        if not name.startswith( input_prefix ): continue
+        applicable_layer_name = name
+        break
+    if applicable_layer_name == None: return
+    log.Info(f"  Layer \"{applicable_layer_name}\" will be processed")
 
-	# Fetch the input tilelayer
-	tilelayer_obj = playdo.GetTilelayerObject(applicable_layer_name)
-	tiles2d = playdo.GetTiles2d(applicable_layer_name)
-	tiles2d_new = tiled_utils.MakeTiles2D(tiles2d)
-#	tiles2d_new = tiled_utils.CopyXMLObject(tiles2d)	# Technically not an object
-	map_height = len(tiles2d)
-	map_width  = len(tiles2d[0])
+    # Fetch the input tilelayer
+    tilelayer_obj = playdo.GetTilelayerObject(applicable_layer_name)
+    tiles2d = playdo.GetTiles2d(applicable_layer_name)
+    tiles2d_new = tiled_utils.MakeTiles2D(tiles2d)
+#    tiles2d_new = tiled_utils.CopyXMLObject(tiles2d)    # Technically not an object
+    map_height = len(tiles2d)
+    map_width  = len(tiles2d[0])
 
-	# Register the property values
-	scroll_x, scroll_y, add_x, add_y = default_values
-	scroll_x, scroll_y = ExtractScrollFromName( applicable_layer_name, input_prefix )
-	log.Info(f"  Scroll Values: {scroll_x}, {scroll_y}")
-#	add_x = ToNum( GetProperty( tilelayer_obj, 'add_x', add_x ) )
-#	add_y = ToNum( GetProperty( tilelayer_obj, 'add_y', add_y ) )
-	add_x = 0
-	add_y = 0
-	add_y -= map_height * scroll_y
+    # Register the property values
+    scroll_x, scroll_y, add_x, add_y = default_values
+    scroll_x, scroll_y = ExtractScrollFromName( applicable_layer_name, input_prefix )
+    log.Info(f"  Scroll Values: {scroll_x}, {scroll_y}")
+#    add_x = ToNum( GetProperty( tilelayer_obj, 'add_x', add_x ) )
+#    add_y = ToNum( GetProperty( tilelayer_obj, 'add_y', add_y ) )
+    add_x = 0
+    add_y = 0
+    add_y -= map_height * scroll_y
 
-	# Process tilelayer data (tiles2d)
-	multiplier_x = 1 / ( 1 - scroll_x )
-	multiplier_y = 1 / ( 1 - scroll_y )
-	for i in range(map_height):
-		ref_y = int( i * multiplier_y )
-		if ref_y >= map_height: continue
-		for j in range(map_width):
-			ref_x = int( j * multiplier_x )
-			if ref_x >= map_width: continue
-			tiles2d_new[i][j] = tiles2d[ref_y][ref_x]
+    # Process tilelayer data (tiles2d)
+    multiplier_x = 1 / ( 1 - scroll_x )
+    multiplier_y = 1 / ( 1 - scroll_y )
+    for i in range(map_height):
+        ref_y = int( i * multiplier_y )
+        if ref_y >= map_height: continue
+        for j in range(map_width):
+            ref_x = int( j * multiplier_x )
+            if ref_x >= map_width: continue
+            tiles2d_new[i][j] = tiles2d[ref_y][ref_x]
 
 
 
-	# Create the list of properties to be added to output tilelayer (in-game view)
-	list_properties = []
-	list_properties.append( ('add_x', str(add_x)) )
-	list_properties.append( ('add_y', str(add_y)) )
-	list_properties.append( ('scroll_x', str(scroll_x)) )
-	list_properties.append( ('scroll_y', str(scroll_y)) )
-	if config_add_transparency:
-		list_properties.append( ('color', config_color) )
+    # Create the list of properties to be added to output tilelayer (in-game view)
+    list_properties = []
+    list_properties.append( ('add_x', str(add_x)) )
+    list_properties.append( ('add_y', str(add_y)) )
+    list_properties.append( ('scroll_x', str(scroll_x)) )
+    list_properties.append( ('scroll_y', str(scroll_y)) )
+    if config_add_transparency:
+        list_properties.append( ('color', config_color) )
 
-	# Create the list of info for the output tilelayer tile (in-editor view)
-	list_info = []
-	list_info.append( ('opacity', config_opacity) )
-	list_info.append( ('offsetx', str(16 * add_x)) )
-	list_info.append( ('offsety', str(16 * (add_y + map_height * scroll_y))) )
-	# TODO check if 1-scroll_x is ok
-	list_info.append( ('parallaxx', str(1/multiplier_x)) )
-	list_info.append( ('parallaxy', str(1/multiplier_y)) )
-	# Tiled automatically clean up the data if any of the value is same as default,
-	#   e.g. offset == 0 or parallax == 1
+    # Create the list of info for the output tilelayer tile (in-editor view)
+    list_info = []
+    list_info.append( ('opacity', config_opacity) )
+    list_info.append( ('offsetx', str(16 * add_x)) )
+    list_info.append( ('offsety', str(16 * (add_y + map_height * scroll_y))) )
+    # TODO check if 1-scroll_x is ok
+    list_info.append( ('parallaxx', str(1/multiplier_x)) )
+    list_info.append( ('parallaxy', str(1/multiplier_y)) )
+    # Tiled automatically clean up the data if any of the value is same as default,
+    #   e.g. offset == 0 or parallax == 1
 
-	# Create the output tilelayer
-	log.Info(f"  Creating output layer \'{output_layer}\'...")
-	tiled_utils.AddTilelayer( playdo, output_layer, tiles2d_new, list_properties, list_info )
+    # Create the output tilelayer
+    log.Info(f"  Creating output layer \'{output_layer}\'...")
+    tiled_utils.AddTilelayer( playdo, output_layer, tiles2d_new, list_properties, list_info )
 
-	log.Info(f"~~End of All Procedures~~\n")
+    log.Info(f"~~End of All Procedures~~\n")
 
 
 
@@ -192,57 +192,57 @@ def AddScroll(playdo, input_prefix, output_layer, default_values):
 '''Utility'''
 
 def ExtractScrollFromName( layer_name, input_prefix ):
-	'''
-	(overrides default values)
-	Return 2 float values from layer name string
-	  e.g.
-		_scroll          -> (  0,    0)
-		_scroll_         -> (  0,    0)
-		_scroll_0.1      -> (0.1,  0.1)
-		_scroll_0.1_-0.2 -> (0.1, -0.2)
-	'''
+    '''
+    (overrides default values)
+    Return 2 float values from layer name string
+      e.g.
+        _scroll          -> (  0,    0)
+        _scroll_         -> (  0,    0)
+        _scroll_0.1      -> (0.1,  0.1)
+        _scroll_0.1_-0.2 -> (0.1, -0.2)
+    '''
 
-	# Remove unnecessary characters
-	trimmed_str = layer_name.replace( input_prefix, "" )
-	if len(trimmed_str) <= 0: return (0,0)
-	if trimmed_str[0] == '_': trimmed_str = trimmed_str[1:]
-	if len(trimmed_str) <= 0: return (0,0)
+    # Remove unnecessary characters
+    trimmed_str = layer_name.replace( input_prefix, "" )
+    if len(trimmed_str) <= 0: return (0,0)
+    if trimmed_str[0] == '_': trimmed_str = trimmed_str[1:]
+    if len(trimmed_str) <= 0: return (0,0)
 
-	# Extract values from the remaining string
-	value_tuple = trimmed_str.split('_')
-	value1, value2 = 0, 0
-	if len(value_tuple) <= 1:
-		value1 = float( value_tuple[0] )
-		value2 = value1
-	else:
-		value1 = float( value_tuple[0] )
-		value2 = float( value_tuple[1] )
-	return ( value1, value2 )
+    # Extract values from the remaining string
+    value_tuple = trimmed_str.split('_')
+    value1, value2 = 0, 0
+    if len(value_tuple) <= 1:
+        value1 = float( value_tuple[0] )
+        value2 = value1
+    else:
+        value1 = float( value_tuple[0] )
+        value2 = float( value_tuple[1] )
+    return ( value1, value2 )
 
 
 
 def GetProperty(obj, prop_name, default_value = ''):
-	'''Return the property value from an object, or the default value if there's none'''
-	value = tiled_utils.GetPropertyFromObject( obj, prop_name )
-	if value == '': value = default_value
-	return value
+    '''Return the property value from an object, or the default value if there's none'''
+    value = tiled_utils.GetPropertyFromObject( obj, prop_name )
+    if value == '': value = default_value
+    return value
 
 
 
 def ToNum( value ):
-	'''Convert property values to either int or float'''
-	# Return int if decimal places not needed
-	try:
-		if float(value) == int(value): return int(value)
-	except ValueError: None
+    '''Convert property values to either int or float'''
+    # Return int if decimal places not needed
+    try:
+        if float(value) == int(value): return int(value)
+    except ValueError: None
 
-	# Return float if is a number
-	try:
-		return float(value)
-	except ValueError: None
+    # Return float if is a number
+    try:
+        return float(value)
+    except ValueError: None
 
-	# Return string if cannot be converted
-	return value_str
+    # Return string if cannot be converted
+    return value_str
 
 
 

--- a/logic/standalone/scroll_adder.py
+++ b/logic/standalone/scroll_adder.py
@@ -12,11 +12,16 @@ import logic.common.tiled_utils as tiled_utils
 #--------------------------------------------------#
 '''Variables'''
 
+DEFAULT_COLOR = 'ffffff/1'	# In-Game View
+DEFAULT_OPACITY = '0.4'		# In-Editor View
+
+# TODO Eventually be setting these in the CLI instead
 # Default values for the configurations
 config_add_transparency = True
+config_color = DEFAULT_COLOR
+config_opacity = DEFAULT_OPACITY
 config_ = True
 
-DEFAULT_COLOR = 'ffffff/0.7'
 
 
 
@@ -50,18 +55,11 @@ def AddScroll(playdo, input_prefix, output_layer, default_values):
 	scroll_x, scroll_y, add_x, add_y = default_values
 	scroll_x, scroll_y = ExtractScrollFromName( applicable_layer_name, input_prefix )
 	log.Info(f"  Scroll Values: {scroll_x}, {scroll_y}")
-	add_x = ToNum( GetProperty( tilelayer_obj, 'add_x', add_x ) )
-	add_y = ToNum( GetProperty( tilelayer_obj, 'add_y', add_y ) )
+#	add_x = ToNum( GetProperty( tilelayer_obj, 'add_x', add_x ) )
+#	add_y = ToNum( GetProperty( tilelayer_obj, 'add_y', add_y ) )
+	add_x = 0
+	add_y = 0
 	add_y -= map_height * scroll_y
-
-	# Create the list of properties to be added to output tilelayer
-	list_properties = []
-	list_properties.append( ('scroll_x', str(scroll_x)) )
-	list_properties.append( ('scroll_y', str(scroll_y)) )
-	list_properties.append( ('add_x', str(add_x)) )
-	list_properties.append( ('add_y', str(add_y)) )
-	if config_add_transparency:
-		list_properties.append( ('color', DEFAULT_COLOR) )
 
 	# Process tilelayer data (tiles2d)
 	multiplier_x = 1 / ( 1 - scroll_x )
@@ -74,9 +72,30 @@ def AddScroll(playdo, input_prefix, output_layer, default_values):
 			if ref_x >= map_width: continue
 			tiles2d_new[i][j] = tiles2d[ref_y][ref_x]
 
+
+
+	# Create the list of properties to be added to output tilelayer (in-game view)
+	list_properties = []
+	list_properties.append( ('add_x', str(add_x)) )
+	list_properties.append( ('add_y', str(add_y)) )
+	list_properties.append( ('scroll_x', str(scroll_x)) )
+	list_properties.append( ('scroll_y', str(scroll_y)) )
+	if config_add_transparency:
+		list_properties.append( ('color', config_color) )
+
+	# Create the list of info for the output tilelayer tile (in-editor view)
+	list_info = []
+	list_info.append( ('opacity', config_opacity) )
+	list_info.append( ('offsetx', str(16 * add_x)) )
+	list_info.append( ('offsety', str(16 * (add_y + map_height * scroll_y))) )
+	list_info.append( ('parallaxx', str(1/multiplier_x)) )
+	list_info.append( ('parallaxy', str(1/multiplier_y)) )
+	# Tiled automatically clean up the data if any of the value is same as default,
+	#   e.g. offset == 0 or parallax == 1
+
 	# Create the output tilelayer
 	log.Info(f"  Creating output layer \'{output_layer}\'...")
-	tiled_utils.AddTilelayer( playdo, output_layer, tiles2d_new, list_properties )
+	tiled_utils.AddTilelayer( playdo, output_layer, tiles2d_new, list_properties, list_info )
 
 	log.Info(f"~~End of All Procedures~~\n")
 


### PR DESCRIPTION
Main Changes:
- Added CLI and Logic modules for the Scroll Tool
- Added `level_playdo.py` function to fetch tilelayer as XML objects instead of tiles2D, which preserves tilelayer's properties
- Added `tiled_utils.py` functions for making tiles2D object and for adding tilelayers more conveniently
- Fix wrong variable names on `SetPropertyOnObject()` in `tiled_utils.py `
- Removed section from `cli_test.py` for ease of use as templates