### PR TITLE
Navigation 1.3

### DIFF
--- a/cli_nav.py
+++ b/cli_nav.py
@@ -34,7 +34,7 @@ list_object_name = [
 ]
 
 # Threshold value for determining redundant routes
-threshold_redundance = 0.9
+threshold_redundance = 0.95
 
 # Exported Object & Layer
 obj_name_default = "TRAVEL_ROUTES_MAP"
@@ -55,7 +55,7 @@ passed_arguments = (
 	layer_name_export
 )
 
-config_calculate_dist = False
+config_calculate_dist = True
 
 
 


### PR DESCRIPTION
## Main Changes (see Trello)
- All previous meta-data objects are removed upon running the tool
- Any valid rectangles and polygons in the node layer are treated as solid
- Threshold value tweaked for checking redundant routes
- Overlapped/Duplicated nodes are automatically deleted
- Placing rectangles with 0-width and 0-height no longer causes error
- (disabled) Check if objects is out of bound