### PR TITLE
Text2Tile 1.1

### DIFF
--- a/cli_text2tile.py
+++ b/cli_text2tile.py
@@ -16,7 +16,6 @@ import logic.standalone.text2tile as main_logic
 '''Adjustable Configurations'''
 
 # In-editor layer and object names
-layer_name_text      = "_text_notes"
 layer_name_export    = "fg_text2tile"
 object_name          = "TEXT_TO_TILES"
 property_name_string = "txt2tile_content"
@@ -27,7 +26,6 @@ property_name_string = "txt2tile_content"
 
 # Passing configurations to logic
 passed_arguments = (
-	layer_name_text, 
 	layer_name_export,
 	object_name,
 	property_name_string

--- a/input/root_dir.toml
+++ b/input/root_dir.toml
@@ -3,12 +3,12 @@
 Q_ROOT = 'C:/Users/qtran/Desktop/PROJECT Whale Nebula/WhaleNebula/Assets/StreamingAssets/levels/'
 Q_INPUT = 'C:/Users/qtran/Desktop/Github Projects/StarTools/input/'
 Q_OUTPUT = 'C:/Users/qtran/Desktop/Github Projects/StarTools/output/'
+Q_GFX = 'C:/Users/qtran/Desktop/PROJECT Whale Nebula/WhaleNebula/Assets/Graphics/'
+
 
 T_ROOT = '/Users/Jimmy/Documents/10 Star Iliad tasks/00-Tiling/10-workspace/levels/'
 T_INPUT = '/Users/Jimmy/20-GitHub/StarTools/input/'
 T_OUTPUT = '/Users/Jimmy/20-GitHub/StarTools/output/'
+T_GFX = '/Users/Jimmy/Documents/10 Star Iliad tasks/00-Tiling/10-workspace/'
 
 T_ROOT1 = '/Users/Jimmy/Library/Application Support/Steam/steamapps/common/Whale Nebula/Contents/Resources/Data/StreamingAssets/levels/'
-
-Q_GFX = 'C:/Users/qtran/Desktop/PROJECT Whale Nebula/WhaleNebula/Assets/Graphics/'
-T_GFX = 'INSERT'

--- a/logic/common/file_utils.py
+++ b/logic/common/file_utils.py
@@ -62,7 +62,7 @@ def GetPatternRoot():
     if (os.path.exists(root_dirs["Q_ROOT"])):
         return root_dirs["Q_ROOT"] + "star_tools/patterns/"
     elif (os.path.exists(root_dirs["T_INPUT"])):
-        return root_dirs["Q_ROOT"] + "star_tools/patterns/"
+        return root_dirs["T_ROOT"] + "star_tools/patterns/"
     else:
         raise Exception("Could not find the Root Level directory. Please update input/root_dir.toml. " +
             "Level directory needs to have a '/star_tools/patterns' folder")
@@ -74,7 +74,7 @@ def GetTemplateRoot():
     if (os.path.exists(root_dirs["Q_ROOT"])):
         return root_dirs["Q_ROOT"] + "star_tools/templates/"
     elif (os.path.exists(root_dirs["T_INPUT"])):
-        return root_dirs["Q_ROOT"] + "star_tools/templates/"
+        return root_dirs["T_ROOT"] + "star_tools/templates/"
     else:
         raise Exception("Could not find the Root Level directory. Please update input/root_dir.toml. " +
             "Level directory needs to have a '/star_tools/templates' folder")
@@ -85,7 +85,7 @@ def GetRemapRoot():
     if (os.path.exists(root_dirs["Q_INPUT"])):
         return root_dirs["Q_ROOT"] + "star_tools/remaps/"
     elif (os.path.exists(root_dirs["T_INPUT"])):
-        return root_dirs["Q_ROOT"] + "star_tools/remaps/"
+        return root_dirs["T_ROOT"] + "star_tools/remaps/"
     else:
         raise Exception("Could not find the Root Level directory. Please update input/root_dir.toml. " +
             "Level directory needs to have a '/star_tools/remaps' folder")

--- a/logic/standalone/text2tile.py
+++ b/logic/standalone/text2tile.py
@@ -11,16 +11,10 @@ import logic.common.tiled_utils as tiled_utils
 #--------------------------------------------------#
 '''Variables'''
 
-'''Default values for the CLI-passed arguments'''
-# In-editor layer and object names
-layer_name_text      = "_text_notes"
-layer_name_export    = "fg_text2tile"
-object_name          = "TEXT_TO_TILES"
-property_name_string = "txt2tile_content"
-
 
 
 '''Local Variables'''
+cli_arguments = []
 list_obj_data = []	# ( (x,y), width, text_string )
 dict_char_index = {}	# KVP: char - Tile ID
 
@@ -43,26 +37,13 @@ def logic(playdo, passed_arguments):
 	log.Must("Drawing characters into tilelayer from XML objects...")
 	start_time = time.time()
 
-	_SetCliArgumentsToGlobal(passed_arguments)
+	for arg in passed_arguments: cli_arguments.append(arg)
 	_ProcessPlaydo(playdo)
 	_SetCharacterIndex()
 	_MakeTilelayer(playdo)
 
 	log.Must(f"~~End of All Procedures~~ ({round( time.time()-start_time, 3 )}s)")
 	log.Extra("")
-
-
-
-def _SetCliArgumentsToGlobal(passed_arguments):
-	global layer_name_text
-	global layer_name_export
-	global object_name
-	global property_name_string
-
-	layer_name_text      = passed_arguments[0]
-	layer_name_export    = passed_arguments[1]
-	object_name          = passed_arguments[2]
-	property_name_string = passed_arguments[3]
 
 
 
@@ -74,10 +55,13 @@ def _SetCliArgumentsToGlobal(passed_arguments):
 def _ProcessPlaydo(playdo):
 	log.Must(f"  Processing playdo for text2file objects...")
 
+	# CLI Arguments
+	object_name          = cli_arguments[1]
+	property_name_string = cli_arguments[2]
+
 	# Register all valid objects
-	obj_layer = playdo.GetObjectGroup(layer_name_text, False)
-	for obj in obj_layer:
-		if obj.get("name") != object_name: continue
+	list_obj = playdo.GetAllObjectsWithName(object_name)
+	for obj in list_obj:
 		if obj.get("width") == None: continue
 
 		text_content = tiled_utils.GetPropertyFromObject(obj, property_name_string)
@@ -145,6 +129,9 @@ def _SetCharacterIndex():
 
 def _MakeTilelayer(playdo):
 	log.Must(f"  Printing characters onto playdo...")
+
+	# CLI Arguments
+	layer_name_export    = cli_arguments[0]
 
 	# Wipe the existing layer if already exists
 	new_tiles2d = playdo.GetBlankTiles2d()

--- a/tool_sfx.py
+++ b/tool_sfx.py
@@ -36,7 +36,7 @@ def WriteSfxNameIntoTiledLevel():
         play.AddPropertiesToObject(txt2tile_obj, properties_dict)
     
     # Next, use text2tile library to process those object updates into graphical tile layer updates
-    t2t_args = ("_text_notes", "fg_text2tile", "TEXT_TO_TILES","txt2tile_content")
+    t2t_args = ("fg_text2tile", "TEXT_TO_TILES", "txt2tile_content")
     t2t.logic(playdo, t2t_args)
     
     # Flush changes


### PR DESCRIPTION
## Main Changes
- `text2tile.py`, arguments are passed down without use of `global`
- `text2tile.py`, now checks for all objectgroups (instead of only a specific one)
- `cli_text2tile.py`, adjusted accordingly in the passed-down argument
- `tool_sfx.py`, adjusted accordingly in the passed-down argument
