### PR TITLE
Sort2 Setter 1.15 (reupload)

### DIFF
--- a/cli_sort.py
+++ b/cli_sort.py
@@ -75,12 +75,9 @@ def main():
     if dict_sortval != None:
         is_split_view = not args.do_not_split    # TODO move these directly into the function argument below?
         is_combined_view = args.combined_view
+        if is_combined_view: is_split_view = False    # Force to use combined view if specified
         reveal_all_lights = args.reveal_all_lights
         has_error = sort_logic.RelocateSortObjects(playdo, dict_sortval, is_split_view, is_combined_view, reveal_all_lights)
-
-    # Milestone 5
-#    if dict_sortval != None:
-#        has_error = sort_logic.RecolorSortObjects(playdo, dict_sortval, True)
 
     user_input = input(f"Commit changes to \'{level_name}\'? (Y/N) ")
     if user_input[0].lower() == 'y': playdo.Write()

--- a/cli_sort.py
+++ b/cli_sort.py
@@ -7,7 +7,7 @@ This includes:
     
 USAGE EXAMPLE:
     python cli_sort.py sf1 --v 0
-    python cli_sort.py sf1 --v 0 --split_view
+    python cli_sort.py sf1 --v 0 --do_not_split
     python cli_sort.py sf1 --v 0 --combined_view
     python cli_sort.py sf1 --v 0 --sort_by_materials
     python cli_sort.py sf1 --v 0 --reveal_all_lights
@@ -22,6 +22,7 @@ import logic.standalone.sort2_setter as sort_logic
 #--------------------------------------------------#
 '''Adjustable Configurations'''
 
+ORDER_4_MATERIALS = ['SPRITE_UNLIT', 'SPRITE_LIT', 'OVERLAY', 'GLOW', 'WINDY']    # First entry has smallest sort number
 
 
 
@@ -38,7 +39,7 @@ def main():
     parser = argparse.ArgumentParser(description = arg_description)
     parser.add_argument('filename', type=str, help = arg_help1)
     parser.add_argument('--v', type=int, choices=[0, 1, 2], default=1, help = arg_help2)
-    parser.add_argument('--split_view', action='store_true')
+    parser.add_argument('--do_not_split', action='store_true')
     parser.add_argument('--combined_view', action='store_true')
     parser.add_argument('--sort_by_materials', action='store_true')
     parser.add_argument('--reveal_all_lights', action='store_true')
@@ -62,12 +63,17 @@ def main():
 
     # Milestone 3
     is_sorting_by_mat = args.sort_by_materials
+    if is_using_sort1 and is_sorting_by_mat:
+        log.Must('\n  WARNING! Attempting to do sort by materials when level is using sort1 standard!')
+        log.Must('   Tool will now proceed without sorting by materials.\n\n')
+        is_sorting_by_mat = False
+    sort_logic.SetMaterialList(ORDER_4_MATERIALS)
     has_error, dict_sortval = sort_logic.ConvertSortValueStandard(playdo, bg_owp_prev_index, fg_anchor_prev_index, max_layer_count, is_using_sort1, is_sorting_by_mat)
     if has_error: return
 
     # Milestone 4
     if dict_sortval != None:
-        is_split_view = args.split_view    # TODO move these directly into the function argument below?
+        is_split_view = not args.do_not_split    # TODO move these directly into the function argument below?
         is_combined_view = args.combined_view
         reveal_all_lights = args.reveal_all_lights
         has_error = sort_logic.RelocateSortObjects(playdo, dict_sortval, is_split_view, is_combined_view, reveal_all_lights)

--- a/cli_sort.py
+++ b/cli_sort.py
@@ -9,6 +9,8 @@ USAGE EXAMPLE:
     python cli_sort.py sf1 --v 0
     python cli_sort.py sf1 --v 0 --split_view
     python cli_sort.py sf1 --v 0 --combined_view
+    python cli_sort.py sf1 --v 0 --sort_by_materials
+    python cli_sort.py sf1 --v 0 --reveal_all_lights
 
 '''
 import argparse

--- a/logic/common/level_playdo.py
+++ b/logic/common/level_playdo.py
@@ -209,9 +209,10 @@ class LevelPlayDo():
 
 
 
-    def GetObjectGroup(self, object_group_name, discard_old = True):
+    def GetObjectGroup(self, object_group_name, discard_old = True, create_new = True):
         ''' Fetches the objectgroup with the provided name from the level element tree if it exists.
             If it does not exists, creates and returns an empty object group for editing.
+            Update: It can now return None instead of creating a new objectgroup
             
             If NONE is provided for object_group_name, returns first object_group found
             
@@ -219,14 +220,16 @@ class LevelPlayDo():
         '''
         
         # Check if object group already exists in the level. If so, return that one for editing
-        
         for object_group in self.level_root.findall('objectgroup'):
             if object_group_name is None or object_group.get('name') == object_group_name:
                 if (discard_old):
                     for object in object_group.findall('object'):
                         object_group.remove(object)
                 return object_group
-        
+
+        # When no objectgroup found, return None if specified to not create a new one
+        if not create_new: return None
+
         # If the object group does NOT exists in the level, create a new one and return it for editing
         new_object_group = ET.SubElement(self.level_root, 'objectgroup', {'name': object_group_name})
         return new_object_group

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -415,21 +415,34 @@ def MoveObjectToNewObjectgroup(playdo, obj, new_objectgroup):
     log.Extra(f"      {obj.get('name')}    {old_objectgroup.get('name')} -> {new_objectgroup.get('name')}")
 
     # Delete old objectgroup if it's empty, otherwise the level might not be able to run
-    if old_objectgroup.find('object') == None:
-        layer_name = old_objectgroup.get('name')
-        log.Extra(f'Removing objectgroup \"{layer_name}\"')
-        parent_folder = GetParentObject(old_objectgroup, playdo)
-        parent_folder.remove(old_objectgroup)
+    DeleteObjectgroupIfEmpty(playdo, old_objectgroup)
 
-        # If parent layer was in a folder before removal, and folder no longer contains tilelayer/objectgroup, remove folder
-        if parent_folder.tag != 'group': return
-        if parent_folder.find('objectgroup') != None: return
-        if parent_folder.find('layer') != None: return
-        folder_name = parent_folder.get('name')
-        log.Extra(f'Removing folder \"{folder_name}\"')
-        root = GetParentObject(parent_folder, playdo)
-        root.remove(parent_folder)
-        # NOTE Is unable to delete nested folder
+def DeleteObjectgroupIfEmpty(playdo, objectgroup):
+    '''
+     Delete old objectgroup if it's empty, otherwise the level might not be able to run
+
+     :param playdo:      A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+     :param objectgroup: Objectgroup to be relocated
+    '''
+    if objectgroup.find('object') != None: return
+
+    # Delete current objectgroup
+    layer_name = objectgroup.get('name')
+    log.Extra(f'Removing objectgroup \"{layer_name}\"')
+    parent_folder = GetParentObject(objectgroup, playdo)
+    parent_folder.remove(objectgroup)
+
+    # If parent layer was in a folder before removal, and folder no longer contains tilelayer/objectgroup, remove folder
+    if parent_folder.tag != 'group': return                 # Do nothing if current objectgroup is not in folder
+    if parent_folder.find('objectgroup') != None: return    #  ^ if folder contains at least 1 objectgroup
+    if parent_folder.find('layer') != None: return          #  ^ if folder contains at least 1 tilelayer
+
+    # Delete folder that houses the current objectgroup
+    folder_name = parent_folder.get('name')
+    log.Extra(f'Removing folder \"{folder_name}\"')
+    root = GetParentObject(parent_folder, playdo)
+    root.remove(parent_folder)
+    # NOTE Is unable to delete nested folder
 
 
     

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -296,6 +296,13 @@ def GetVerticesFromObject( tiled_object ):
 
 
 
+def IsTilelayerNameValid(tilelayer_name):
+    if tilelayer_name.startswith('fg_'): return True
+    if tilelayer_name.startswith('bg_'): return True
+    return False
+
+
+
 
 
 #--------------------------------------------------#

--- a/logic/standalone/sort2_setter.py
+++ b/logic/standalone/sort2_setter.py
@@ -35,9 +35,14 @@ LIST_OBJ_REAL_LIGHT_NAME = {
     "light_line"
 }
 
-ORDER_4_MATERIALS = ['SPRITE_UNLIT', 'OVERLAY', 'GLOW', 'SPRITE_LIT']
+ORDER_4_MATERIALS = ['SPRITE_UNLIT', 'SPRITE_LIT', 'OVERLAY', 'GLOW', 'WINDY']    # First entry has smallest sort number
 MAT_PROPERTY_NAME = '_material'
+config_put_default_mat_highest = False    # If true, objects with no material specified would be placed above specified objects
 
+# During --sort_by_materials command,
+#  This will be the list of object name that would server as the anchor/separator
+# If you don't want any anchor, you can set the array empty, i.e. []
+config_material_anchor = ['water_line', 'water_fill']
 
 
 
@@ -237,9 +242,25 @@ def RenameTilelayer(playdo):
     # Scan through all objects to check their properties and see if affected by renaming
     log.Must("   Additional references in objects will be updated to match the new tilelayer names")
     count = 1
+    list_obj_with_multiple_properties = []
     for obj in playdo.GetAllObjects():
         has_change = _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo)
-        if has_change: count += 1
+        if has_change:
+            count += 1
+            list_obj_with_multiple_properties.append(obj)
+
+    # There is for the weird bug where only 1 property can be updated each time somehow
+    # The band-aid solution here is to keep processing objects until no name-swap can occur
+    while len(list_obj_with_multiple_properties) > 0:
+        list_temp = []
+        for obj in list_obj_with_multiple_properties:
+            has_change = _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo)
+            if has_change:
+                count += 1
+                list_temp.append(obj)
+        list_obj_with_multiple_properties = []
+        for obj in list_temp: list_obj_with_multiple_properties.append(obj)
+
     if count == 1:
         log.Must(f"    (no object references need to be changed)")
 
@@ -286,7 +307,9 @@ def _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo):
     layer_name = tiled_utils.GetParentObject(obj, playdo).get('name')
     for curr_property in properties.findall('property'):
         has_change = has_change or _RenameLayerInProperty(curr_property, list_name_bef_aft, count, obj_name, layer_name)
-        # Does not return immediately, in case an object has more than 1 property that needs updating
+        if has_change: return True
+        # Originally, this would not not return immediately, in case an object has more than 1 property that needs updating
+        # However, it seems only 1 property can be updated at a time, returning earlier wouldn't make a difference
     return has_change
 
 def _RenameLayerInProperty(curr_property, list_name_bef_aft, count, obj_name, layer_name):
@@ -304,7 +327,7 @@ def _RenameLayerInProperty(curr_property, list_name_bef_aft, count, obj_name, la
     if new_value != old_value:
         curr_property.set('value', new_value)
         if obj_name == None : obj_name = 'no-name obj'
-        log.Must(f"    ({count}) \'{obj_name}\' in layer \'{layer_name}\' will change \'{curr_property.get('name')}\' to \'{new_value}\'")
+        log.Must(f"    ({count}) \'{obj_name}\' in layer \'{layer_name}\' will update \'{curr_property.get('name')}\', -> \'{new_value}\'")
         return True
     return False
 
@@ -548,6 +571,10 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
             if max_name_len < len(obj_name): max_name_len = len(obj_name)
 
 
+#    print(is_sorting_by_mat)
+#    print(is_using_sort1)
+    if is_sorting_by_mat and is_using_sort1: log.Must('    WARNING! Level is using sort1 when attempt to also sort by material.')
+
     # Assign new sort values in properties
     replace_key_bef_aft1 = None
     replace_key_bef_aft2 = None
@@ -558,7 +585,7 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
 
         # Sort all objects by meterials if requested
 #        old_len = len(list_obj)
-        if is_sorting_by_mat: list_obj = _SortBucketByMterials(list_obj)
+        if is_sorting_by_mat: list_obj = _SortBucketByMaterials(list_obj)
 #        new_len = len(list_obj)
 #        print(f'LEN: {old_len} -> {new_len}')
 
@@ -591,7 +618,12 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
             if old_sort != sort2_value:
                 change_indicator = '*'
                 count_sort_changed += 1
-            log.Must(f'      {_IndentBack(obj_name, max_name_len+2, True)} {change_indicator} {old_sort} -> {sort2_value}')
+            mat_indicator = ''
+            if is_sorting_by_mat:
+                mat_indicator = tiled_utils.GetPropertyFromObject(obj, MAT_PROPERTY_NAME)
+                if mat_indicator == '': mat_indicator =  '    (---)'
+                else:                   mat_indicator = f'    ({mat_indicator})'
+            log.Must(f'      {_IndentBack(obj_name, max_name_len+2, True)} {change_indicator} {old_sort} -> {sort2_value}{mat_indicator}')
 
             tiled_utils.SetPropertyOnObject(obj, '_sort2', sort2_value)
 
@@ -612,10 +644,48 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
 
     return count_sort_changed, dict_all_buckets
 
-
-def _SortBucketByMterials(list_obj):
+def _SortBucketByMaterials(list_obj):
     '''
-     Docstring for _SortBucketByMterials
+     Docstring for _SortBucketByMaterials
+     Each group of objects separated by water objects is treated like a "standalone bucket"
+      "Divider" Condition - Basically when encountering a water object, separate
+    
+     :param list_obj: Description
+    '''
+    # Separate the objects into multiple lists
+    list_of_list_obj = []
+    temp_list = []
+    for obj in list_obj:
+        obj_name = obj.get('name')
+        if obj_name in config_material_anchor:
+#        if obj_name == 'water_line' or obj_name == 'water_fill':
+            list_of_list_obj.append(temp_list)
+            temp_list = []
+            list_of_list_obj.append([obj])
+        else:
+            temp_list.append(obj)
+
+    # Append the temp list if the last one isn't water, meaning they haven't been appended to the full list yet
+    last_obj_name = list_obj[-1].get('name')
+    if not (last_obj_name in config_material_anchor):
+#    if not (last_obj_name == 'water_line' or last_obj_name == 'water_fill'):
+        list_of_list_obj.append(temp_list)
+
+    # Sort each smaller list, then append individual obj to full list
+    full_list = []
+    for index, curr_list in enumerate(list_of_list_obj):
+        list_of_list_obj[index] = _SortSmallerListByMterials(list_of_list_obj[index])
+        for obj in list_of_list_obj[index]:
+            obj_name = obj.get('name')
+            full_list.append(obj)
+
+#    full_list = _SortSmallerListByMterials(list_obj)
+    return full_list
+
+
+def _SortSmallerListByMterials(list_obj):
+    '''
+     Docstring for _SortSmallerListByMterials
     
      :param list_obj: Description
     '''
@@ -629,9 +699,12 @@ def _SortBucketByMterials(list_obj):
 #    print(f'FULL LIST : {len(remaining_list)} objects')
 #    print(f'  Checking {len(ORDER_4_MATERIALS)} MATS')
 
-    # Checking in reversed order to Unity, i.e. GLOW should have smaller number than SPRITE_UNLIT
+    # reference: ORDER_4_MATERIALS = ['SPRITE_UNLIT', 'SPRITE_LIT', 'OVERLAY', 'GLOW']
+    # OVERGLOWLAY should have highest number; SPRITE_UNLIT smallest
+
+    # Can do reversed(ORDER_4_MATERIALS) here if needed
     #  NOTE Has to reverse the list each time we're using it, can't do it only once at the beginning
-    list_mat = reversed(ORDER_4_MATERIALS)
+    list_mat = (ORDER_4_MATERIALS)
 
     # Make a new list with all objects based on each one's material value
     return_list = []
@@ -655,18 +728,31 @@ def _SortBucketByMterials(list_obj):
         # Assign a unique key to each value
         #  e.g. 'GLOW,1.4' => key is 1400+n
         #  e.g. 'GLOW,2.3' => key is 2300+n
+        # nvm they're all sorted alphabetically now
         dict_sort = {}
         BIG_NUM = 1000
         obj_id = 0
         for obj in obj_in_mat:
             mat_value = tiled_utils.GetPropertyFromObject(obj, MAT_PROPERTY_NAME)
+            '''
             specified_value = 0
             try:    specified_value = float(mat_value.split(',')[1])
             except: specified_value = 0            
             obj_id += 1
             curr_key = obj_id + BIG_NUM * specified_value
             dict_sort[curr_key] = obj
+            '''
+
+#            dict_sort[obj] = mat_value
+
+#            '''
+            obj_id += 1
+            curr_key = f'{mat_value} {obj_id}'
+            dict_sort[curr_key] = obj
+#            '''
+
         dict_sort = dict(sorted(dict_sort.items()))
+#        dict_sort = dict(sorted(dict_sort.items(), key=lambda item: item[1]))
 
         # Append to final list
 #        for obj in obj_in_mat: return_list.append(obj)
@@ -674,11 +760,27 @@ def _SortBucketByMterials(list_obj):
         log_msg += f'{mat} ({len(obj_in_mat)}), '
 #        print(f'    {mat}\t{len(obj_in_mat)} objects added; Now at {len(return_list)}')
 
+    '''
+    # If there are objects with unspecified material, warn the user
     if len(remaining_list) == len(list_obj):
         log.Must(f'    WARNING! All {len(remaining_list)} objects do not have \'_material\' property specified!')
     elif len(remaining_list) > 0:
-        log.Must(f'    WARNING! Only first {len(list_obj) - len(remaining_list)} objects have \'_material\' property specified, the last {len(remaining_list)} objects do not!')
-    for obj in remaining_list: return_list.append(obj)
+        msg = f'    WARNING! Only first {len(list_obj) - len(remaining_list)} objects have \'_material\' property specified, the '
+        if config_put_default_mat_highest: msg += 'last'
+        else:                              msg += 'first'
+        msg += f' {len(remaining_list)} objects do not!'
+        log.Must(msg)
+    '''
+
+    # If config is true, append the default mat after other objects to put default objs above all
+    if config_put_default_mat_highest:
+        for obj in remaining_list: return_list.append(obj)
+    else:
+        temp_list = []
+        for obj in remaining_list: temp_list.append(obj)
+        for obj in return_list: temp_list.append(obj)
+        return_list = temp_list
+
 #    print(f'  {mat}\t{len(obj_in_mat)} objects added; Now at {len(return_list)}')
     log_msg += f'UNSPECIFIED ({len(remaining_list)})'
 #    print(log_msg)

--- a/logic/standalone/sort2_setter.py
+++ b/logic/standalone/sort2_setter.py
@@ -183,7 +183,6 @@ def RenameTilelayer(playdo):
 
     # Check to make sure there is no "overlapping" in tilelayer names (continued)
     if _CheckIfTilelayerNamesOverlap(playdo): return DEFAULT_ERROR
-    log.Must('     All good!')
 
 
     for layer_name in playdo.GetAllTileLayerNames():
@@ -243,7 +242,7 @@ def RenameTilelayer(playdo):
 
     # Inform user that there is no OWP layer, ask if want to proceed normally or exit
     if not contains_bg_owp:
-        log.Must("    WARNING! Level does not contain the BG OWP anchor")
+        log.Must("    WARNING! Level does not contain the BG OWP anchor\n")
 
     # Scan through all objects to check their properties and see if affected by renaming
     log.Must("   Additional references in objects will be updated to match the new tilelayer names")
@@ -260,19 +259,96 @@ def RenameTilelayer(playdo):
 
 
 
+def _CheckIfTilelayerNamesOverlap(playdo):
+    '''
+     Returns True if one tilelayer name contains another name as substring, which is bad.
+     Prints out error message when it happens.
+     TODO Print a warning instead? Will return the list of problematic layer name instead
+     
+     :param playdo: A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+    '''
+    list_all_tilelayer_name = playdo.GetAllTileLayerNames()
+    log.Info('    Checking if tilelayer names overlap with one another...')
+
+    # Compare each tilelayer's name with one another, until one is found to be substring of another
+    overlapped_pair = None
+    for name1 in list_all_tilelayer_name:
+        if not tiled_utils.IsTilelayerNameValid(name1): continue
+        skip_same_name = False
+        for name2 in list_all_tilelayer_name:
+            if not tiled_utils.IsTilelayerNameValid(name2): continue
+#            print(f'\"{name1}\" and \"{name2}\"')
+            if (name1 == name2) and (not skip_same_name):
+                skip_same_name = True
+                continue
+            if name1 in name2:
+                overlapped_pair = f' (\"{name1}\" & \"{name2}\")'
+                break
+        if overlapped_pair != None: break
+    if overlapped_pair == None:
+        log.Info('     All good!')
+        return False
+
+    # Log the error message
+    log.Must(f'    ERROR! Some tilelayers have overlapping names!{overlapped_pair}')
+    log.Must(f'     This may cause error when updating name references in object properties.')
+    log.Must(f'     Please rename tilelayers to ensure none is a substring of another, e.g.')
+    log.Must(f'      \"fg_ground_below\" & \"fg_ground\"  : NOT okay')
+    log.Must(f'      \"fg_ground_below\" & \"fg_ground1\" : okay')
+    log.Must("")
+    return True
+
+
+
 def _TilelayerHasSortProperty(playdo, layer_name):
     for layer in playdo.level_root.findall('.//layer'):
         if layer.get('name') != layer_name: continue
         if tiled_utils.GetPropertyFromObject(layer, '_sort') != '': return True
     return False
 
+# https://docs.google.com/document/d/1GN5UMAfNQC44met51Ms4MZ575rQlZAk61CYXeYQelzg/edit?tab=t.i244z3rn90j6
+def _GetStringOfNewName(layer_name, layer_counter):
+    '''
+     This renames tilelayer from old to new standard
+     Returns tuple : ( new_name, layer_counter, is_bg_owp, is_fg_parallax )
+    '''
 
+    # Keep track of /fx, then remove it temporarily during renaming
+    has_fx = '/fx' in layer_name
+    layer_name = layer_name.replace('/fx', '')
+
+    # Case 1 - OWP layer is always renamed to 'bg_owp_30k'
+    if layer_name.startswith('bg') and 'owp' in layer_name.lower():
+        layer_name = "bg_owp_30k"
+        if has_fx: layer_name += '/fx'
+        return (layer_name, layer_counter, True, False)
+    if layer_name.startswith('fg') and ('parallax' in layer_name.lower() or 'paralax' in layer_name.lower()):
+        layer_name = "fg_parallax_25k"
+        if has_fx: layer_name += '/fx'
+        return (layer_name, layer_counter, False, True)
+
+    # Case 2 - Other layers, 'bg_1_wall' -> 'bg_wall'
+    #  1. Remove the ending 'k' in previous sort2 before renaming, e.g. bg_wall_5k
+    #  2. Lowercase
+    #  3. Non-letter -> space, then trim
+    #  4. Space -> underscore
+    if layer_name[-1] == 'k': layer_name = layer_name[:-1]
+    layer_name = layer_name.lower()
+    layer_name = re.sub(r'[^a-z]+', ' ', layer_name)
+    layer_name = layer_name.strip()
+    layer_name = layer_name.replace(' ', '_')
+
+    # Add the sort number at the end, then add back /fx if needed
+    layer_name += f"_{layer_counter * 5}k"
+    if has_fx: layer_name += '/fx'
+    return (layer_name, -1, False, False)
 
 def _RenameTilelayer(playdo, original_name, layer_name):
     for layer in playdo.level_root.findall('.//layer'):
         if layer.get('name') != original_name: continue
         layer.set('name', layer_name)
         return
+
 
 
 def _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo):
@@ -324,81 +400,6 @@ def _RenameLayerInProperty(curr_property, list_name_bef_aft):
             new_value = new_value.replace(name_bef, name_aft)
     return new_value    # Property value is unchanged if it doesn't contain any of the tilelayer name before-change
 
-def _CheckIfTilelayerNamesOverlap(playdo):
-    '''
-     Returns True if one tilelayer name contains another name as substring, which is bad.
-     Prints out error message when it happens.
-     
-     :param playdo: A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
-    '''
-    list_all_tilelayer_name = playdo.GetAllTileLayerNames()
-    log.Info('    Checking if tilelayer names overlap with one another...')
-
-    # Compare each tilelayer's name with one another, until one is found to be substring of another
-    overlapped_pair = None
-    for name1 in list_all_tilelayer_name:
-        if not tiled_utils.IsTilelayerNameValid(name1): continue
-        skip_same_name = False
-        for name2 in list_all_tilelayer_name:
-            if not tiled_utils.IsTilelayerNameValid(name2): continue
-#            print(f'\"{name1}\" and \"{name2}\"')
-            if (name1 == name2) and (not skip_same_name):
-                skip_same_name = True
-                continue
-            if name1 in name2:
-                overlapped_pair = f' (\"{name1}\" & \"{name2}\")'
-                break
-        if overlapped_pair != None: break
-    if overlapped_pair == None: return False
-
-    # Log the error message
-    log.Must(f'    ERROR! Some tilelayers have overlapping names!{overlapped_pair}')
-    log.Must(f'     This may cause error when updating name references in object properties.')
-    log.Must(f'     Please rename tilelayers to ensure none is a substring of another, e.g.')
-    log.Must(f'      \"fg_ground_below\" & \"fg_ground\"  : NOT okay')
-    log.Must(f'      \"fg_ground_below\" & \"fg_ground1\" : okay')
-    log.Must("")
-    return True
-
-
-
-# TODO move the function up
-# https://docs.google.com/document/d/1GN5UMAfNQC44met51Ms4MZ575rQlZAk61CYXeYQelzg/edit?tab=t.i244z3rn90j6
-def _GetStringOfNewName(layer_name, layer_counter):
-    '''
-     This renames tilelayer from old to new standard
-     Returns tuple : ( new_name, layer_counter, is_bg_owp, is_fg_parallax )
-    '''
-
-    # Keep track of /fx, then remove it temporarily during renaming
-    has_fx = '/fx' in layer_name
-    layer_name = layer_name.replace('/fx', '')
-
-    # Case 1 - OWP layer is always renamed to 'bg_owp_30k'
-    if layer_name.startswith('bg') and 'owp' in layer_name.lower():
-        layer_name = "bg_owp_30k"
-        if has_fx: layer_name += '/fx'
-        return (layer_name, layer_counter, True, False)
-    if layer_name.startswith('fg') and ('parallax' in layer_name.lower() or 'paralax' in layer_name.lower()):
-        layer_name = "fg_parallax_25k"
-        if has_fx: layer_name += '/fx'
-        return (layer_name, layer_counter, False, True)
-
-    # Case 2 - Other layers, 'bg_1_wall' -> 'bg_wall'
-    #  1. Remove the ending 'k' in previous sort2 before renaming, e.g. bg_wall_5k
-    #  2. Lowercase
-    #  3. Non-letter -> space, then trim
-    #  4. Space -> underscore
-    if layer_name[-1] == 'k': layer_name = layer_name[:-1]
-    layer_name = layer_name.lower()
-    layer_name = re.sub(r'[^a-z]+', ' ', layer_name)
-    layer_name = layer_name.strip()
-    layer_name = layer_name.replace(' ', '_')
-
-    # Add the sort number at the end, then add back /fx if needed
-    layer_name += f"_{layer_counter * 5}k"
-    if has_fx: layer_name += '/fx'
-    return (layer_name, -1, False, False)
 
 
 
@@ -558,7 +559,6 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
                 log.Must(f'     WARNING! \'{obj_name}\' in \'{layer_name}\' has no assigned sort2')
                 continue
 
-
         # Create the "key" that allows sorting items by values
         #  e.g. As string, it has trouble handling single-digit numbers
         # old_sort example : "fg_tiles/13"
@@ -603,9 +603,6 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
             obj_name = obj.get('name')
             if max_name_len < len(obj_name): max_name_len = len(obj_name)
 
-
-#    print(is_sorting_by_mat)
-#    print(is_using_sort1)
     if is_sorting_by_mat and is_using_sort1: log.Must('    WARNING! Level is using sort1 when attempt to also sort by material.')
 
     # Assign new sort values in properties
@@ -617,10 +614,7 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
         list_obj = value
 
         # Sort all objects by meterials if requested
-#        old_len = len(list_obj)
         if is_sorting_by_mat: list_obj = _SortBucketByMaterials(list_obj)
-#        new_len = len(list_obj)
-#        print(f'LEN: {old_len} -> {new_len}')
 
         # If the BG OWP index is not invalid
         #  Check if current the bucket is BG and above the original OWP anchor layer
@@ -679,11 +673,9 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
 
 def _SortBucketByMaterials(list_obj):
     '''
-     Docstring for _SortBucketByMaterials
-     Each group of objects separated by water objects is treated like a "standalone bucket"
-      "Divider" Condition - Basically when encountering a water object, separate
-    
-     :param list_obj: Description
+     Objects separated by a "divider object" are treated like in a "standalone bucket"
+      "Divider" condition - Basically when encountering a water object currently
+     :param list_obj: The list of XML objects in the currently processed bucket
     '''
     # Separate the objects into multiple lists
     list_of_list_obj = []
@@ -691,7 +683,6 @@ def _SortBucketByMaterials(list_obj):
     for obj in list_obj:
         obj_name = obj.get('name')
         if obj_name in config_material_anchor:
-#        if obj_name == 'water_line' or obj_name == 'water_fill':
             list_of_list_obj.append(temp_list)
             temp_list = []
             list_of_list_obj.append([obj])
@@ -701,39 +692,25 @@ def _SortBucketByMaterials(list_obj):
     # Append the temp list if the last one isn't water, meaning they haven't been appended to the full list yet
     last_obj_name = list_obj[-1].get('name')
     if not (last_obj_name in config_material_anchor):
-#    if not (last_obj_name == 'water_line' or last_obj_name == 'water_fill'):
         list_of_list_obj.append(temp_list)
 
     # Sort each smaller list, then append individual obj to full list
     full_list = []
     for index, curr_list in enumerate(list_of_list_obj):
-        list_of_list_obj[index] = _SortSmallerListByMterials(list_of_list_obj[index])
+        list_of_list_obj[index] = _SortSmallerListByMaterials(list_of_list_obj[index])
         for obj in list_of_list_obj[index]:
             obj_name = obj.get('name')
             full_list.append(obj)
-
-#    full_list = _SortSmallerListByMterials(list_obj)
     return full_list
 
-
-def _SortSmallerListByMterials(list_obj):
+def _SortSmallerListByMaterials(list_obj):
     '''
-     Docstring for _SortSmallerListByMterials
-    
-     :param list_obj: Description
+     Does a sort for smaller groups inside a bucket, separated by aforementioned "divider object"
+     :param list_obj: The list of XML objects in the currently processed bucket
     '''
-    # TODO sort by mat within bucket first before appending; log
-
-#    print('NOW SORTING BY MATERIALS')
-
     # For keeping track of which objects have no materials unregistered
     remaining_list = []
     for obj in list_obj: remaining_list.append(obj)
-#    print(f'FULL LIST : {len(remaining_list)} objects')
-#    print(f'  Checking {len(ORDER_4_MATERIALS)} MATS')
-
-    # reference: ORDER_4_MATERIALS = ['SPRITE_UNLIT', 'SPRITE_LIT', 'OVERLAY', 'GLOW']
-    # OVERGLOWLAY should have highest number; SPRITE_UNLIT smallest
 
     # Can do reversed(ORDER_4_MATERIALS) here if needed
     #  NOTE Has to reverse the list each time we're using it, can't do it only once at the beginning
@@ -741,69 +718,32 @@ def _SortSmallerListByMterials(list_obj):
 
     # Make a new list with all objects based on each one's material value
     return_list = []
-    log_msg = '    Material resorted status: '
     for mat in list_mat:
-#        print(f'  CURR MAT : {mat}')
         obj_in_mat = []
 
         # Check if objects have matching materials
         for obj in remaining_list:
             mat_value = tiled_utils.GetPropertyFromObject(obj, MAT_PROPERTY_NAME)
             has_match = (mat_value != '') and (mat in mat_value)
-#            if mat_value == '': continue
-#            print(f'  {mat} vs {mat_value} | Match? {has_match}')
-#            if not mat_value in mat: continue
             if not has_match: continue
             obj_in_mat.append(obj)
         for obj in obj_in_mat: remaining_list.remove(obj)
 
-        # Further sort by specifications if applicable
-        # Assign a unique key to each value
-        #  e.g. 'GLOW,1.4' => key is 1400+n
-        #  e.g. 'GLOW,2.3' => key is 2300+n
-        # nvm they're all sorted alphabetically now
+        # Further sort, based on the material list provided in CLI
+        # Key is a unique string based on each value, e.g. 'GLOW,1.4 0' 'GLOW,1.4 1' 'GLOW,2.3 2' 'GLOW,0.9 3'
+        # Value is the XML object associated
         dict_sort = {}
         BIG_NUM = 1000
         obj_id = 0
         for obj in obj_in_mat:
             mat_value = tiled_utils.GetPropertyFromObject(obj, MAT_PROPERTY_NAME)
-            '''
-            specified_value = 0
-            try:    specified_value = float(mat_value.split(',')[1])
-            except: specified_value = 0            
-            obj_id += 1
-            curr_key = obj_id + BIG_NUM * specified_value
-            dict_sort[curr_key] = obj
-            '''
-
-#            dict_sort[obj] = mat_value
-
-#            '''
             obj_id += 1
             curr_key = f'{mat_value} {obj_id}'
             dict_sort[curr_key] = obj
-#            '''
-
         dict_sort = dict(sorted(dict_sort.items()))
-#        dict_sort = dict(sorted(dict_sort.items(), key=lambda item: item[1]))
 
         # Append to final list
-#        for obj in obj_in_mat: return_list.append(obj)
         for obj in dict_sort.values(): return_list.append(obj)
-        log_msg += f'{mat} ({len(obj_in_mat)}), '
-#        print(f'    {mat}\t{len(obj_in_mat)} objects added; Now at {len(return_list)}')
-
-    '''
-    # If there are objects with unspecified material, warn the user
-    if len(remaining_list) == len(list_obj):
-        log.Must(f'    WARNING! All {len(remaining_list)} objects do not have \'_material\' property specified!')
-    elif len(remaining_list) > 0:
-        msg = f'    WARNING! Only first {len(list_obj) - len(remaining_list)} objects have \'_material\' property specified, the '
-        if config_put_default_mat_highest: msg += 'last'
-        else:                              msg += 'first'
-        msg += f' {len(remaining_list)} objects do not!'
-        log.Must(msg)
-    '''
 
     # If config is true, append the default mat after other objects to put default objs above all
     if config_put_default_mat_highest:
@@ -813,13 +753,7 @@ def _SortSmallerListByMterials(list_obj):
         for obj in remaining_list: temp_list.append(obj)
         for obj in return_list: temp_list.append(obj)
         return_list = temp_list
-
-#    print(f'  {mat}\t{len(obj_in_mat)} objects added; Now at {len(return_list)}')
-    log_msg += f'UNSPECIFIED ({len(remaining_list)})'
-#    print(log_msg)
-
     return return_list
-    return list_obj
 
 
 
@@ -837,7 +771,6 @@ def _GetLayerNumberFromSortValue(is_fg_layer, curr_sort, max_layer_count, is_usi
      :param max_layer_count: int, maximum number of BG or FG tilelayers, whichever applicable
      :param is_using_sort1:  bool, whether current object is using sort1
     '''
-
     # Formula is different between sort1 and sort2
     if is_using_sort1:
         layer_num = int(curr_sort/10) + 1
@@ -860,6 +793,9 @@ def _GetLayerNumberFromSortValue(is_fg_layer, curr_sort, max_layer_count, is_usi
 
 
 def _Resort_DevObjects(obj):
+    '''
+     Set the debugging sort1 property to a fixed sort2 value
+    '''
     obj_name = obj.get('name')
     old_sort = tiled_utils.GetPropertyFromObject(obj, 'sort')
     old_sort += tiled_utils.GetPropertyFromObject(obj, '_sort')
@@ -876,6 +812,10 @@ def _Resort_DevObjects(obj):
 
 
 def _RemoveOldSortProperty(obj, playdo, max_len):
+    '''
+     If the object is still using sort1 properties, they are removed from object immediately
+     Utility function also automatically removes <properties> tag is it's the last property in object
+    '''
     has_old_sort_a = tiled_utils.RemovePropertyFromObject(obj, 'sort')
     has_old_sort_b = tiled_utils.RemovePropertyFromObject(obj, '_sort')
     if has_old_sort_a or has_old_sort_b:
@@ -925,20 +865,19 @@ def RelocateSortObjects(playdo, dict_sortval, change_view_split, change_view_com
     _ChangeObjectColorByMaterial(playdo)
 
     log.Must("")
-#    log.Info(f"  --- Finished relocating {1} objects! ---\n")
+
 
 
 
 
 def _SetLightVisibility(playdo, dict_sortval, reveal_all_lights):
     '''
-     Docstring for _SetLightVisibility TODO
-    
-     :param playdo: Description
-     :param dict_sortval: Description
-     :param reveal_all_lights: Description
+     Set the visibility (eye icon in Tiled app) on all the objectgroups with lighting objects    
+     :param playdo:            A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+     :param dict_sortval:      Dictionary from resorting sort2 objects, key stores the "bucket" info and value stores the array of objects
+     :param reveal_all_lights: If True, all lighting objectgroups have visibility set ON
     '''
-    # TODO log
+#    log.Must("Setting objectgroups with lighting objects' visibility to {reveal_all_lights}")
 
     # Always set the real-lights objectgroup's visibility to be ON
     real_light_objectgroup = playdo.GetObjectGroup(REAL_LIGHT_OBJECTGROUP_NAME, False, False)
@@ -963,7 +902,13 @@ def _SetLightVisibility(playdo, dict_sortval, reveal_all_lights):
 
 
 def _RelocateToSplitView(playdo, dict_sortval):
-    '''TODO'''
+    '''
+     Move the lighting objectgroups next to the tilelayers they are above of.
+     Certain objects are excluded from being moved if they originally reside in certain layers, e.g. breakwall
+
+     :param playdo:       A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+     :param dict_sortval: Dictionary from resorting sort2 objects, key stores the "bucket" info and value stores the array of objects
+    '''
     # Assign new sort values in properties
     log.Must(f"    Applying \"Split View\" into {len(dict_sortval)} groups...")
 #    reversed_dict = dict(reversed(list(dict_sortval.items()))) # Reverse the order to remember insert position
@@ -1010,7 +955,12 @@ def _RelocateToSplitView(playdo, dict_sortval):
 
 
 def _RelocateAllRealLight(playdo):
-    '''TODO'''
+    '''
+     Create a new objectgroup for all "Real Light" objects
+     Does nothing is no such objects exist in the level yet
+
+     :param playdo: A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+    '''
     # Move all objects to the "Real Light" objectgroup
     log.Must(f"    Moving \"Real Light\" objects into objectgroup \"{REAL_LIGHT_OBJECTGROUP_NAME}\"...")
     list_real_light_obj = []
@@ -1037,14 +987,17 @@ def _RelocateAllRealLight(playdo):
     tiled_utils.MoveObjectgroupAfter(playdo, real_light_objectgroup, meta_objectgroup, False)
     for obj in list_real_light_obj:
         tiled_utils.MoveObjectToNewObjectgroup(playdo, obj, real_light_objectgroup)
-#    tiled_utils.DeleteObjectgroupIfEmpty(playdo, real_light_objectgroup)
 
-    # Move meta objectgroup to be 1st in level, otherwise level might not load in-game
-#        tiled_utils.MoveMetaObjectgroupToBottom(playdo)    # Deprecated. Level no longer breaks when lighting comes first?
 
 
 def _RelocateToCombinedView(playdo, dict_sortval):
-    '''TODO'''
+    '''
+     Move all lighting objects into one single objectgroup
+     NOTE The exclusion-check from the split-view function is not present for this function
+
+     :param playdo:       A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+     :param dict_sortval: Dictionary from resorting sort2 objects, key stores the "bucket" info and value stores the array of objects
+    '''
     log.Must("    Applying \"Combine View\"...")
     for key, value in dict_sortval.items():
         is_fg = key[0]
@@ -1072,12 +1025,10 @@ def _FindAdjacentTilelayer(playdo, layer_name):
      :param playdo:     A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
      :param layer_name: Name of the objectgroup, e.g. objects_fg_15k
     '''
-    
     # Extra the needed info from layer name
     tuple = layer_name.split('_')    # e.g. `bg_5k`
     is_fg = (tuple[1] == 'fg')       # e.g. False
     sortval = f'_{tuple[2]}'         # e.g. '_5k'
-#    print(f'{tuple} -> {is_fg}, {sortval}')
     
     # Find the correct tilelayer
     list_layer_names = playdo.GetAllTileLayerNames()
@@ -1091,7 +1042,6 @@ def _FindAdjacentTilelayer(playdo, layer_name):
     # If none is found, likely indicate it's below the first BG/FG tilelayer, e.g. fg_0k
     # In that case, use the tilelayer right below that instead
     log.Extra(f'    WARNING! Cannot find tilelayer with sort \'{sortval}\', may insert objectgroup at wrong spot.')
-#    for index, name in enumerate(list_layer_names):
     for name in list_layer_names:
         # Skip if not in the FG/BG
         if (is_fg) and (not ('fg' in name)): continue
@@ -1100,26 +1050,24 @@ def _FindAdjacentTilelayer(playdo, layer_name):
         # Skip if tilelayer name not found
         # Usually this only happens for obejcts with _0k, _-5k, etc., since tilelayer starts at _5k
         if not '_5k' in name: continue
-#        return playdo.GetTilelayer(list_layer_names[index-1], False), False
         return playdo.GetTilelayer(name, False), False
 
     # If still nothing is found, log error; This should never happen!
     log.Must('    ERROR! No viable tilelayer found! Inserting before \'meta\' objectgroup...')
-#    return None, False
-#    return playdo.GetTilelayer(None, False), False
-    return playdo.GetObjectGroup('meta', False)
+    return playdo.GetObjectGroup('meta', False), False
+
 
 
 def _ChangeObjectColorByMaterial(playdo):
     '''
-    If object name is light_global, give it type = 10
-    If object name is light_<anything else>, give it type = 11
-    If AT object has material NONE, give it type = 12
-    If AT object has material SPRITE_UNLIT, give it type = 13
-    If AT object has material SPRITE_LIT, give it type = 14
-    If AT object has material OVERLAY, give it type = 15
-    If AT object has material GLOW , give it type = 16
-    If AT object has material WINDY , give it type = 17
+        If object name is light_global, give it type = 10
+        If object name is light_<anything else>, give it type = 11
+        If AT object has material NONE, give it type = 12
+        If AT object has material SPRITE_UNLIT, give it type = 13
+        If AT object has material SPRITE_LIT, give it type = 14
+        If AT object has material OVERLAY, give it type = 15
+        If AT object has material GLOW , give it type = 16
+        If AT object has material WINDY , give it type = 17
     '''
     log.Must(f"    Coloring in-editor colors of objects based on their materials...")
     for obj in playdo.GetAllObjects():
@@ -1141,33 +1089,6 @@ def _ChangeObjectColorByMaterial(playdo):
 def _ChangeObjectType(obj, type_str):
     log.Extra(f"      Object \"{obj.get('name')}\" has changed type to \"{type_str}\"")
     obj.set('type', type_str)
-
-
-
-
-
-#--------------------------------------------------#
-'''Milestone 5'''
-
-def RecolorSortObjects(playdo, dict_sortval, do_recolor = False):
-    ''' TBA '''
-    log.Must(f"  Procedure 5 - Recolor lighting objects based on color-value")
-
-
-
-
-
-    log.Info(f"  --- Finished procedure! ---\n")
-
-
-
-
-
-
-#--------------------------------------------------#
-'''To be deleted'''
-
-
 
 
 

--- a/logic/standalone/sort2_setter.py
+++ b/logic/standalone/sort2_setter.py
@@ -35,7 +35,7 @@ LIST_OBJ_REAL_LIGHT_NAME = {
     "light_line"
 }
 
-ORDER_4_MATERIALS = ['SPRITE_UNLIT', 'SPRITE_LIT', 'OVERLAY', 'GLOW', 'WINDY']    # First entry has smallest sort number
+ORDER_4_MATERIALS = []    # First entry has smallest sort number; Argument is supplied from CLI
 MAT_PROPERTY_NAME = '_material'
 config_put_default_mat_highest = False    # If true, objects with no material specified would be placed above specified objects
 
@@ -44,6 +44,8 @@ config_put_default_mat_highest = False    # If true, objects with no material sp
 # If you don't want any anchor, you can set the array empty, i.e. []
 config_material_anchor = ['water_line', 'water_fill']
 
+# If objectgroup contains these, the objects inside are unaffected by the split-view procedure
+split_view_exclusion_name = ["break", "fade", "secret"]
 
 
 
@@ -376,6 +378,9 @@ def _GetStringOfNewName(layer_name, layer_counter):
 
 #--------------------------------------------------#
 '''Milestone 3'''
+
+def SetMaterialList(cli_order):
+    for mat_property in cli_order: ORDER_4_MATERIALS.append(mat_property)
 
 def ConvertSortValueStandard(playdo, bg_owp_prev_index, fg_anchor_prev_index, max_layer_count, is_using_sort1, is_sorting_by_mat):
     '''
@@ -857,7 +862,7 @@ def _RemoveOldSortProperty(obj, playdo, max_len):
 #--------------------------------------------------#
 '''Milestone 4'''
 
-def RelocateSortObjects(playdo, dict_sortval, change_view_split = False, change_view_combine = False, reveal_all_lights = False):
+def RelocateSortObjects(playdo, dict_sortval, change_view_split, change_view_combine, reveal_all_lights):
     '''
      Relocate all the sort2 lighting objects.
      Split View:
@@ -889,6 +894,7 @@ def RelocateSortObjects(playdo, dict_sortval, change_view_split = False, change_
         _RelocateToCombinedView(playdo, dict_sortval)
 
     _SetLightVisibility(playdo, dict_sortval, reveal_all_lights)
+    _ChangeObjectColorByMaterial(playdo)
 
     log.Must("")
 #    log.Info(f"  --- Finished relocating {1} objects! ---\n")
@@ -952,6 +958,13 @@ def _RelocateToSplitView(playdo, dict_sortval):
             parent_layer = tiled_utils.GetParentObject(obj, playdo)
             parent_name = parent_layer.get('name')
             if parent_name == layer_name: continue
+
+            # Object is excluded from the split_view separation algorithm if parent layer contains substring from array
+            is_obj_excluded = False
+            for excluded_name in split_view_exclusion_name:
+                if excluded_name in parent_name: is_obj_excluded = True
+            if is_obj_excluded: continue
+
             tiled_utils.MoveObjectToNewObjectgroup(playdo, obj, objectgroup_destination)
 
         # Relocate/insert the objectgroup to the correct tilelayer, e.g. with matching sortval
@@ -964,9 +977,7 @@ def _RelocateToSplitView(playdo, dict_sortval):
 def _RelocateAllRealLight(playdo):
     # Move all objects to the "Real Light" objectgroup
     log.Must(f"    Moving \"Real Light\" objects into objectgroup \"{REAL_LIGHT_OBJECTGROUP_NAME}\"...")
-    real_light_objectgroup = playdo.GetObjectGroup(REAL_LIGHT_OBJECTGROUP_NAME, False)
-    meta_objectgroup = playdo.GetObjectGroup('meta', False)
-    tiled_utils.MoveObjectgroupAfter(playdo, real_light_objectgroup, meta_objectgroup, False)
+    list_real_light_obj = []
     for obj in playdo.GetAllObjects():
         # Ignore if objects don't need to be moved
         obj_name = obj.get('name')
@@ -977,8 +988,20 @@ def _RelocateAllRealLight(playdo):
         parent_name = parent_layer.get('name')
         if parent_name == REAL_LIGHT_OBJECTGROUP_NAME: continue
 
-        # Move object and log message
+        list_real_light_obj.append(obj)
+
+    # Skip function if there is no real light object in level yet
+    if list_real_light_obj == []:
+        log.Must(f"     No \"Real Light\" object found, so objectgroup is not created here")
+        return
+
+    # Move object and log message
+    real_light_objectgroup = playdo.GetObjectGroup(REAL_LIGHT_OBJECTGROUP_NAME, False)
+    meta_objectgroup = playdo.GetObjectGroup('meta', False)
+    tiled_utils.MoveObjectgroupAfter(playdo, real_light_objectgroup, meta_objectgroup, False)
+    for obj in list_real_light_obj:
         tiled_utils.MoveObjectToNewObjectgroup(playdo, obj, real_light_objectgroup)
+#    tiled_utils.DeleteObjectgroupIfEmpty(playdo, real_light_objectgroup)
 
     # Move meta objectgroup to be 1st in level, otherwise level might not load in-game
 #        tiled_utils.MoveMetaObjectgroupToBottom(playdo)    # Deprecated. Level no longer breaks when lighting comes first?
@@ -1048,6 +1071,40 @@ def _FindAdjacentTilelayer(playdo, layer_name):
 #    return None, False
 #    return playdo.GetTilelayer(None, False), False
     return playdo.GetObjectGroup('meta', False)
+
+
+def _ChangeObjectColorByMaterial(playdo):
+    '''
+    If object name is light_global, give it type = 10
+    If object name is light_<anything else>, give it type = 11
+    If AT object has material NONE, give it type = 12
+    If AT object has material SPRITE_UNLIT, give it type = 13
+    If AT object has material SPRITE_LIT, give it type = 14
+    If AT object has material OVERLAY, give it type = 15
+    If AT object has material GLOW , give it type = 16
+    If AT object has material WINDY , give it type = 17
+    '''
+    log.Must(f"    Coloring in-editor colors of objects based on their materials...")
+    for obj in playdo.GetAllObjects():
+        # Ignore if objects don't need to be moved
+        obj_name = obj.get('name')
+        mat_value = tiled_utils.GetPropertyFromObject(obj, MAT_PROPERTY_NAME)
+
+        if obj_name == None:                continue
+        elif obj_name == 'light_global':    _ChangeObjectType(obj, '10')
+        elif 'light_' in obj_name:          _ChangeObjectType(obj, '11')
+        elif not obj_name.startswith('AT'): continue
+        elif mat_value == '':               _ChangeObjectType(obj, '12')
+        elif mat_value == 'SPRITE_UNLIT':   _ChangeObjectType(obj, '13')
+        elif mat_value == 'SPRITE_LIT':     _ChangeObjectType(obj, '14')
+        elif mat_value == 'OVERLAY':        _ChangeObjectType(obj, '15')
+        elif mat_value == 'GLOW':           _ChangeObjectType(obj, '16')
+        elif mat_value == 'WINDY':          _ChangeObjectType(obj, '17')
+
+def _ChangeObjectType(obj, type_str):
+    log.Must(f"      Object \"{obj.get('name')}\" has changed type to \"{type_str}\"")
+    obj.set('type', type_str)
+
 
 
 

--- a/logic/standalone/sort2_setter.py
+++ b/logic/standalone/sort2_setter.py
@@ -169,7 +169,7 @@ def RenameTilelayer(playdo):
     log.Info("  Procedure 2 - Renaming tilelayers...")
 
     # Default error value; 2nd & 3rd value are irrelevant since the program would exit upon detecting an error
-    DEFAULT_ERROR = (True, -1, [-1,-1])
+    DEFAULT_ERROR = (True, -1, -1, -1)
 
     list_name_bef_aft = []    # List of tuple, each stores a (<name_before>, <name_after>)
     contains_bg_owp = False
@@ -180,6 +180,11 @@ def RenameTilelayer(playdo):
     bg_anchor_prev_index = -1    # For later : BG "anchor" from OWP; Ensure objects previously above OWP remains above after renaming
     fg_anchor_prev_index = -1    # For later : FG "anchor" from Parallax; same as above
     max_layer_count = []         # For later : Total layer numbers for BG & FG tilelayers
+
+    # Check to make sure there is no "overlapping" in tilelayer names (continued)
+    if _CheckIfTilelayerNamesOverlap(playdo): return DEFAULT_ERROR
+    log.Must('     All good!')
+
 
     for layer_name in playdo.GetAllTileLayerNames():
         if not (layer_name.startswith('fg') or layer_name.startswith('bg')): continue
@@ -240,29 +245,11 @@ def RenameTilelayer(playdo):
     if not contains_bg_owp:
         log.Must("    WARNING! Level does not contain the BG OWP anchor")
 
-
     # Scan through all objects to check their properties and see if affected by renaming
     log.Must("   Additional references in objects will be updated to match the new tilelayer names")
     count = 1
-    list_obj_with_multiple_properties = []
     for obj in playdo.GetAllObjects():
-        has_change = _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo)
-        if has_change:
-            count += 1
-            list_obj_with_multiple_properties.append(obj)
-
-    # There is for the weird bug where only 1 property can be updated each time somehow
-    # The band-aid solution here is to keep processing objects until no name-swap can occur
-    while len(list_obj_with_multiple_properties) > 0:
-        list_temp = []
-        for obj in list_obj_with_multiple_properties:
-            has_change = _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo)
-            if has_change:
-                count += 1
-                list_temp.append(obj)
-        list_obj_with_multiple_properties = []
-        for obj in list_temp: list_obj_with_multiple_properties.append(obj)
-
+        count = _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo)
     if count == 1:
         log.Must(f"    (no object references need to be changed)")
 
@@ -288,33 +275,44 @@ def _RenameTilelayer(playdo, original_name, layer_name):
         return
 
 
-
 def _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo):
     '''
      Check through an object's properties to see if there is any outdated tilelayer name references.
-     Return True if the object's reference has been updated
+     Return the cumulative count of properties that have been updated thus far
     
      :param obj:               XML Object, its properties would be checked
      :param list_name_bef_aft: (string, string), stores the tilelayer name before and after renaming respectively
      :param count:             int, number of objects that have been updated so far
      :param playdo:            A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
     '''
+
     # Only proceed if the object contains properties
     properties = obj.find('properties')
-    if properties == None: return
+    if properties == None: return count
 
-    # Check each property individually
-    has_change = False
+    # Grab all properties into a dictionary, only add item if there is change in property value
+    dict_property = {}    # Dictionary of the updated properties, empty if none is update
+    for curr_property in properties.findall('property'):
+        prop_name = curr_property.get('name')
+        old_value = curr_property.get('value')
+        new_value = _RenameLayerInProperty(curr_property, list_name_bef_aft)
+        if new_value != old_value: dict_property[prop_name] = new_value
+    if len(dict_property) == 0: return count
+
+    # For logging purpose
     obj_name = obj.get('name')
     layer_name = tiled_utils.GetParentObject(obj, playdo).get('name')
-    for curr_property in properties.findall('property'):
-        has_change = has_change or _RenameLayerInProperty(curr_property, list_name_bef_aft, count, obj_name, layer_name)
-        if has_change: return True
-        # Originally, this would not not return immediately, in case an object has more than 1 property that needs updating
-        # However, it seems only 1 property can be updated at a time, returning earlier wouldn't make a difference
-    return has_change
+    
+    # Loop through the dictionary to update the applicable objects with changes
+    for key, value in dict_property.items():
+        prop_name  = key
+        prop_value = value
+        tiled_utils.SetPropertyOnObject(obj, prop_name, prop_value)
+        log.Must(f"    ({count}) \'{obj_name}\' in layer \'{layer_name}\' will update \'{prop_name}\', -> \'{prop_value}\'")
+        count += 1
+    return count
 
-def _RenameLayerInProperty(curr_property, list_name_bef_aft, count, obj_name, layer_name):
+def _RenameLayerInProperty(curr_property, list_name_bef_aft):
     '''Adjust the property value if it contains a tilelayer name that needs to be renamed'''
     # Scan through all properties
     old_value = curr_property.get('value')
@@ -324,17 +322,47 @@ def _RenameLayerInProperty(curr_property, list_name_bef_aft, count, obj_name, la
         name_aft = tuple[1].replace('/fx','')
         if name_bef in old_value:
             new_value = new_value.replace(name_bef, name_aft)
+    return new_value    # Property value is unchanged if it doesn't contain any of the tilelayer name before-change
 
-    # Set the property value if there is a change
-    if new_value != old_value:
-        curr_property.set('value', new_value)
-        if obj_name == None : obj_name = 'no-name obj'
-        log.Must(f"    ({count}) \'{obj_name}\' in layer \'{layer_name}\' will update \'{curr_property.get('name')}\', -> \'{new_value}\'")
-        return True
-    return False
+def _CheckIfTilelayerNamesOverlap(playdo):
+    '''
+     Returns True if one tilelayer name contains another name as substring, which is bad.
+     Prints out error message when it happens.
+     
+     :param playdo: A TILED level in an easily moldable state (wrapped around ElementTree + some helpers)
+    '''
+    list_all_tilelayer_name = playdo.GetAllTileLayerNames()
+    log.Info('    Checking if tilelayer names overlap with one another...')
+
+    # Compare each tilelayer's name with one another, until one is found to be substring of another
+    overlapped_pair = None
+    for name1 in list_all_tilelayer_name:
+        if not tiled_utils.IsTilelayerNameValid(name1): continue
+        skip_same_name = False
+        for name2 in list_all_tilelayer_name:
+            if not tiled_utils.IsTilelayerNameValid(name2): continue
+#            print(f'\"{name1}\" and \"{name2}\"')
+            if (name1 == name2) and (not skip_same_name):
+                skip_same_name = True
+                continue
+            if name1 in name2:
+                overlapped_pair = f' (\"{name1}\" & \"{name2}\")'
+                break
+        if overlapped_pair != None: break
+    if overlapped_pair == None: return False
+
+    # Log the error message
+    log.Must(f'    ERROR! Some tilelayers have overlapping names!{overlapped_pair}')
+    log.Must(f'     This may cause error when updating name references in object properties.')
+    log.Must(f'     Please rename tilelayers to ensure none is a substring of another, e.g.')
+    log.Must(f'      \"fg_ground_below\" & \"fg_ground\"  : NOT okay')
+    log.Must(f'      \"fg_ground_below\" & \"fg_ground1\" : okay')
+    log.Must("")
+    return True
 
 
 
+# TODO move the function up
 # https://docs.google.com/document/d/1GN5UMAfNQC44met51Ms4MZ575rQlZAk61CYXeYQelzg/edit?tab=t.i244z3rn90j6
 def _GetStringOfNewName(layer_name, layer_counter):
     '''
@@ -913,7 +941,8 @@ def _SetLightVisibility(playdo, dict_sortval, reveal_all_lights):
     # TODO log
 
     # Always set the real-lights objectgroup's visibility to be ON
-    playdo.GetObjectGroup(REAL_LIGHT_OBJECTGROUP_NAME, False).set('visible', '1')
+    real_light_objectgroup = playdo.GetObjectGroup(REAL_LIGHT_OBJECTGROUP_NAME, False, False)
+    if real_light_objectgroup != None: real_light_objectgroup.set('visible', '1')
 
     # Set visibility to the sorted objectgroups based on boolean
     visible_value = '0'
@@ -924,16 +953,17 @@ def _SetLightVisibility(playdo, dict_sortval, reveal_all_lights):
         sortval = key[1]
         list_obj = value
 
-        # Lazy way to find the objectgroups where all sorted objects are in
-        first_obj = list_obj[0]
-        curr_objectgroup = tiled_utils.GetParentObject(first_obj, playdo)
-        curr_objectgroup.set('visible', visible_value)
+        # Some objects are not relocated, so I'm grabbing the parent one by one
+        for obj in list_obj:
+            curr_objectgroup = tiled_utils.GetParentObject(obj, playdo)
+            curr_objectgroup.set('visible', visible_value)
 
 
 
 
 
 def _RelocateToSplitView(playdo, dict_sortval):
+    '''TODO'''
     # Assign new sort values in properties
     log.Must(f"    Applying \"Split View\" into {len(dict_sortval)} groups...")
 #    reversed_dict = dict(reversed(list(dict_sortval.items()))) # Reverse the order to remember insert position
@@ -951,6 +981,18 @@ def _RelocateToSplitView(playdo, dict_sortval):
         layer_name += f'{str(sortval * 5)}k'
         log.Must(f"     {layer_name}\t{len(list_obj)} objects")
 
+        # Object is excluded from the split_view separation algorithm if parent layer contains substring from array
+        list_obj_not_excluded = []
+        for obj in list_obj:
+            parent_layer = tiled_utils.GetParentObject(obj, playdo)
+            parent_name = parent_layer.get('name')
+            is_obj_excluded = False
+            for excluded_name in split_view_exclusion_name:
+                if excluded_name in parent_name: is_obj_excluded = True
+            if is_obj_excluded: continue
+            list_obj_not_excluded.append(obj)
+        if list_obj_not_excluded == []: continue    # Skip creating new objectgroup if all objects are excluded
+
         # Relocate objects between layers
         objectgroup_destination = playdo.GetObjectGroup(layer_name, False)
         for obj in list_obj:
@@ -958,13 +1000,6 @@ def _RelocateToSplitView(playdo, dict_sortval):
             parent_layer = tiled_utils.GetParentObject(obj, playdo)
             parent_name = parent_layer.get('name')
             if parent_name == layer_name: continue
-
-            # Object is excluded from the split_view separation algorithm if parent layer contains substring from array
-            is_obj_excluded = False
-            for excluded_name in split_view_exclusion_name:
-                if excluded_name in parent_name: is_obj_excluded = True
-            if is_obj_excluded: continue
-
             tiled_utils.MoveObjectToNewObjectgroup(playdo, obj, objectgroup_destination)
 
         # Relocate/insert the objectgroup to the correct tilelayer, e.g. with matching sortval
@@ -975,6 +1010,7 @@ def _RelocateToSplitView(playdo, dict_sortval):
 
 
 def _RelocateAllRealLight(playdo):
+    '''TODO'''
     # Move all objects to the "Real Light" objectgroup
     log.Must(f"    Moving \"Real Light\" objects into objectgroup \"{REAL_LIGHT_OBJECTGROUP_NAME}\"...")
     list_real_light_obj = []
@@ -1008,6 +1044,7 @@ def _RelocateAllRealLight(playdo):
 
 
 def _RelocateToCombinedView(playdo, dict_sortval):
+    '''TODO'''
     log.Must("    Applying \"Combine View\"...")
     for key, value in dict_sortval.items():
         is_fg = key[0]
@@ -1102,7 +1139,7 @@ def _ChangeObjectColorByMaterial(playdo):
         elif mat_value == 'WINDY':          _ChangeObjectType(obj, '17')
 
 def _ChangeObjectType(obj, type_str):
-    log.Must(f"      Object \"{obj.get('name')}\" has changed type to \"{type_str}\"")
+    log.Extra(f"      Object \"{obj.get('name')}\" has changed type to \"{type_str}\"")
     obj.set('type', type_str)
 
 


### PR DESCRIPTION
Main Changes:
- Fixed issue where cannot update multiple properties on the same object simultaneously .
(vvv When sorting by material vvv)
- Allow user to specify the order of materials
- Allow whether to put unassigned ones at bottom or top
- Treat suffix as string instead of float during the finer sort, e.g. `GLOW,1.4` and `GLOW,2.3`
- Show matierial during sort (Removed warnings when objects have none)
- Allow user to specify "anchor", basically certain objects to retain the previous order e.g. If for a water obj there are 4 below and 17 above it, there will still be 4 below and 17 above after sorting by materials
- Added warning message when attempt to process sort1 when sorting by materials