### PR TITLE
LevelEdit Tool v1.5

### DIFF
--- a/cli_level_edit.py
+++ b/cli_level_edit.py
@@ -7,6 +7,9 @@ USAGE EXAMPLE:
 	clear; python cli_level_edit.py --v 1
 	clear; python /Users/Jimmy/20-GitHub/StarTools/cli_level_edit.py --v 1
 
+	python cli_level_edit.py
+	python cli_level_edit.py --backup
+	python cli_level_edit.py --rewind
 '''
 import argparse
 import toml
@@ -14,6 +17,7 @@ import logic.common.file_utils as file_utils
 import logic.common.log_utils as log
 import logic.common.level_playdo as play
 import logic.standalone.level_edit as level_edit
+import logic.common.backup_utils as backup_utils
 
 #--------------------------------------------------#
 '''Adjustable Configurations'''
@@ -47,8 +51,24 @@ def main():
 	# Use argparse to get the filename & other optional arguments from the command line
 	parser = argparse.ArgumentParser(description = arg_description)
 	parser.add_argument('--v', type=int, choices=[0, 1, 2], default=1, help = arg_help2)
+	parser.add_argument('--backup', action='store_true')
+	parser.add_argument('--rewind', action='store_true')
 	args = parser.parse_args()
 	log.SetVerbosityLevel(args.v)
+
+	# Back up feature
+	if args.backup and args.rewind:
+		log.Must('ERROR! Attempting to create and restore backups simultaneously.')
+		log.Must('Please only do one action at a time')
+		return
+	if args.rewind:
+		log.Must('Restoring the latest backup of all levels from ZIP...')
+		backup_utils.DecompressAllBackups()
+		return
+	if args.backup:
+		log.Must('Creating the backup for all levels into ZIP...')
+		backup_utils.CompressAllBackupsIntoZip(None)
+		# After creating the backup ZIP, will still carry out operations next
 
 	# Read TOML
 	toml_path = curr_toml

--- a/input/level_edit-MASTER_example.toml
+++ b/input/level_edit-MASTER_example.toml
@@ -1,28 +1,57 @@
 # This is the big sample TOML that contains all possible arguments
 # Will be updating this TOML from time to time
 
+# Notes : 
+#  - Some values can be in lowercase
+#   - If the example value is in ALL-CAP, it means value has to be an exact match
 
 
-# Currently Available Actions:
-#  - REMOVE_PROPERTY
-#  - (more TBA)
-	ACTION = ["REMOVE_PROPERTY", "_material", "#Q"]			# These are automatically added to the property list
-#	ACTION = ["ADD_PROPERTY", "_material", "SPRITE_UNLIT"]	# Automatically add property to objects, set default value if empty
+# ---------- [Actions] ---------- #
+	ACTION = ["REMOVE_PROPERTY", "_material"]				# This removes the "_material" property in included objects
+	ACTION = ["REMOVE_PROPERTY", "_material", "#Q"]			# This removes both "_material" and "#Q" property in included objects
+
+	ACTION = ["ADD_PROPERTY", "_material", "SPRITE_UNLIT"]	# This adds the "_material" property AND set the value to be "SPRITE_UNLIT"
+															# If the object already has an assigned value, no action would be done
 
 
-# Target levels
-	TARGET_LEVEL_FILES = ["z01", "a02"]						# If first item starts with 'ALL', all levels would be checked
-#	TARGET_LEVEL_FILES = ["aLl_lv", "2nd item ignored"]		# Another example value
+
+# ---------- [Target Levels] ---------- #
+	TARGET_LEVEL_FILES = ["all"]			# This targets all levels in folder
+	TARGET_LEVEL_FILES = ["z01"]			# This targets 1 specific level
+	TARGET_LEVEL_FILES = ["z01", "a02"]		# This targets all specific levels in the list
+
+	TARGET_ACTIVE_OBJECT_LAYERS_ONLY    = "true"		# If "true", only active objects would be included
+														# This ignores layers not starting in "collision_" or "objects_"
 
 
-# Inclusion Rules 
-	TARGET_ACTIVE_OBJECT_LAYERS_ONLY    = "nAh"								# If starts with "true", only active objects would be included
-	TARGET_OBJECTS_WITH_NAME            = ["NAMELESS", "AT_ANY", "door"]	# If this key is absent, all objects would be targetted
-	TARGET_OBJECTS_WITH_PROPERTY        = ["_sort2"]						#  ^
-#	TARGET_OBJECTGROUP_WITH_THESE_WORDS = ["breakwall"]						#  ^ ; Check whether the object's layer contain any of it as substring
 
-# Exclusion Rules
-#	IGNORE_OBJECTS_WITH_NAME            = ["door", "AT", "AT_radial"]
-	IGNORE_OBJECTGROUP_WITH_THESE_WORDS = ["breakwall"]                  # (same as in Inclusion Rule)
+# ---------- [Inclusion Rules] ---------- #
+# When these not specified, the check is skipped, so the tool basically does this:
+#  If no name       is specified, all objects would be targetted regardless of name
+#  If no property   is specified, all objects would be targetted regardless of properties
+#  If no layer name is specified, all objects would be targetted regardless of layer name
 
+
+	TARGET_OBJECTS_WITH_NAME            = ["door"]				# This targets objects named exactly as "door"
+	TARGET_OBJECTS_WITH_NAME            = ["door", "water"]		# This targets objects named exactly as "door" OR "water"
+	TARGET_OBJECTS_WITH_NAME            = ["NAMELESS"]			#  Special Case - This targets objects without name, e.g. for nameless terrain objects
+	TARGET_OBJECTS_WITH_NAME            = ["AT_ANY"]			#  Special Case - This targets objects exactly named "AT" OR with prefix "AT_"
+
+	TARGET_OBJECTS_WITH_PROPERTY        = ["_sort2"]			# This targets objects containing "_sort2" as its property
+	TARGET_OBJECTS_WITH_PROPERTY        = ["_sort2", "_sort"]	# This targets objects containing "_sort2" OR "_sort" as its property
+
+	TARGET_OBJECTGROUP_WITH_THESE_WORDS = ["collisions"]		# This targets objects with "collisions_" in layer name, so nothing from "objects_"
+	TARGET_OBJECTGROUP_WITH_THESE_WORDS = ["_fg_", "_bg_"]		# This targets basically the lighting objects in split-view, e.g. "objects_fg_10k" or "objects_bg_5k"
+
+
+
+# ---------- [Exclusion Rules] ---------- #
+# Usually mirror the corresponding Inclusion Rules
+
+	IGNORE_OBJECTS_WITH_NAME            = ["door", "AT", "AT_radial"]		# If object name is an exact match of ANY of this, object gets ignored
+
+	IGNORE_OBJECTS_WITH_PROPERTY        = ["_material"]						# If object contains ANY of these properties, object gets ignored
+
+	IGNORE_OBJECTGROUP_WITH_THESE_WORDS = ["breakwall"]						# If layer name contains ANY of these as substring, object gets ignored
+																			# e.g. Lets you skip altering objects inside "objects_breakwall"
 

--- a/input/level_edit-add_material.toml
+++ b/input/level_edit-add_material.toml
@@ -1,4 +1,4 @@
-# This TOML is for deleting the "#Q" property from all collisions objects
+# This TOML is for adding the "_material" property. See [NOTE] at bottom for details
 
 	ACTION = ["ADD_PROPERTY", "_material", "SPRITE_UNLIT"]
 
@@ -10,7 +10,13 @@
 
 	IGNORE_OBJECTS_WITH_PROPERTY        = ["_material"]	# Comment this to disable
 
+
+
 #  [NOTE]
-# This assumes no object is having "_material" property with empty value
-#  If there are indeed such objects, you can comment out the last Exclusion Rule
-#  Just that doing so makes the tool run slower
+
+# If the object doesn't have the property, property will be added with the specified default value
+# Object is IGNORED if it does have the property, with or without any value assigned
+#  - I assume no object is having the property but with an empty value
+#  - The last Exclusion Rule ignores objects that already has the property, which hopefully makes the tool run faster
+
+# Only objects in active layer, AND is an AT object will be targetted

--- a/input/level_edit-remove_sfx.toml
+++ b/input/level_edit-remove_sfx.toml
@@ -1,11 +1,15 @@
-# This TOML is for deleting the "#Q" property from all collisions objects
+# This TOML is for deleting the "sfx" and "#Q" properties from all collisions objects
 
 	ACTION = ["REMOVE_PROPERTY", "sfx", "#Q"]
 
 	TARGET_LEVEL_FILES = ["ALL"]
 
+	# This line mostly emphasizes that inactive layers are targetted
+	# You can technically remove the line and the tool would stay functionally identical
 	TARGET_ACTIVE_OBJECT_LAYERS_ONLY    = "false"
-	TARGET_OBJECTS_WITH_NAME            = ["NAMELESS"]	# not needed?
+
+	# You can specify the name of collision objects if needed
 	TARGET_OBJECTGROUP_WITH_THESE_WORDS = ["collisions"]
+#	TARGET_OBJECTS_WITH_NAME            = ["NAMELESS"]
 
 

--- a/logic/common/tiled_utils.py
+++ b/logic/common/tiled_utils.py
@@ -381,8 +381,12 @@ def MakePolypoints( list_pos, is_reversed = False, polygon_xy = (0,0) ):
 
 
 
-def RemovePropertyFromObject( tiled_object, property_name ):
-    '''Return True if the property exists in object'''
+def RemovePropertyFromObject( tiled_object, property_name, add_q_property = True ):
+    '''
+     Return True if the property exists in object
+     By default, would add the #Q property if there is no other property
+      This is not needed for collision objects (need checking before calling this function)
+    '''
 
     # Get the properties of object
     properties = tiled_object.find('properties')
@@ -397,7 +401,7 @@ def RemovePropertyFromObject( tiled_object, property_name ):
     if not has_property_to_be_removed: return False
 
     # If the property getting removed is the only property, add the no-op #Q property
-    if len(properties) == 0:
+    if len(properties) == 0 and add_q_property:
         SetPropertyOnObject(tiled_object, '#Q', '')
     return True
 

--- a/logic/standalone/level_edit.py
+++ b/logic/standalone/level_edit.py
@@ -103,7 +103,7 @@ def FilterObjects(playdo, dict_config):
 		parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
 		has_property = False
 
-		# Check name
+		# Check name; Skip checking if target list is empty
 		if include_name_list != []:
 			if obj_name == None:
 				if not NAMELESS in include_name_list: continue
@@ -111,13 +111,14 @@ def FilterObjects(playdo, dict_config):
 				if obj_name in include_name_list: dummy()
 				elif AT_ANY in include_name_list and (obj_name == 'AT' or obj_name.startswith('AT_')): dummy()
 				else: continue
-		if obj_name == None:
-			if NAMELESS in exclude_name_list: continue
-		else:
-			if obj_name in exclude_name_list: continue
-			if AT_ANY in exclude_name_list and (obj_name == 'AT' or obj_name.startswith('AT_')): continue
+		if exclude_name_list != []:
+			if obj_name == None:
+				if NAMELESS in exclude_name_list: continue
+			else:
+				if obj_name in exclude_name_list: continue
+				if AT_ANY in exclude_name_list and (obj_name == 'AT' or obj_name.startswith('AT_')): continue
 
-		# Check property
+		# Check property; Skip checking if target list is empty
 		if include_prop_list != []:
 			has_property = False
 			for property in include_prop_list:
@@ -173,8 +174,10 @@ def PerformAction(playdo, list_obj, do_action):
 	for obj in list_obj:
 		# Do action
 		if do_action[0] == ACTION_REMOVE_PROP:
+			parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
+			is_collision_obj = parent_name.startswith('collisions')
 			for property in do_action[1:]:
-				tiled_utils.RemovePropertyFromObject(obj, property)
+				tiled_utils.RemovePropertyFromObject(obj, property, add_q_property=(not is_collision_obj))
 		if do_action[0] == ACTION_ADD_PROP:
 			prop_name = do_action[1]
 			default_value = do_action[2]


### PR DESCRIPTION
Main Changes:
 - Added backup & rewind features
 - Added various comments to TOMLs
 - Tiled Utils, when removing properties, can explicitly disable adding `#Q` property by default
 - LevelEdit, when removing properties, no longer auto-add `#Q` property if objects are in `collisions` layer