### PR TITLE
Sort2 Setter v2.1

### DIFF
--- a/cli_sort.py
+++ b/cli_sort.py
@@ -11,7 +11,9 @@ USAGE EXAMPLE:
     python cli_sort.py sf1 --v 0 --combined_view
     python cli_sort.py sf1 --v 0 --sort_by_materials
     python cli_sort.py sf1 --v 0 --reveal_all_lights
+    python cli_sort.py sf1 --v 0 -- rewind
 
+    clear; python cli_sort.py w01_BEFORE --v 2
 '''
 import argparse
 import logic.common.file_utils as file_utils
@@ -59,15 +61,15 @@ def main():
         backup_utils.RestoreBackup(playdo)
         return
 
-    # Milestone 1
+    # Milestone 1 - Check if level is using either of the sort standards correctly
     has_error, is_using_sort1 = sort_logic.ErrorCheckSortOrder(playdo)
     if has_error: return
 
-    # Milestone 2
+    # Milestone 2 - Rename all tilelayers, check if there are more than 6 tilelayers in FG or BG
     has_error, bg_owp_prev_index, fg_anchor_prev_index, max_layer_count = sort_logic.RenameTilelayer(playdo)
     if has_error: return
 
-    # Milestone 3
+    # Milestone 3 - Update all sort values in object properties
     is_sorting_by_mat = args.sort_by_materials
     if is_using_sort1 and is_sorting_by_mat:
         log.Must('\n  WARNING! Attempting to do sort by materials when level is using sort1 standard!')
@@ -77,13 +79,16 @@ def main():
     has_error, dict_sortval = sort_logic.ConvertSortValueStandard(playdo, bg_owp_prev_index, fg_anchor_prev_index, max_layer_count, is_using_sort1, is_sorting_by_mat)
     if has_error: return
 
-    # Milestone 4
+    # Milestone 4 - Group objects into appropriate objectgroups
     if dict_sortval != None:
         is_split_view = not args.do_not_split    # TODO move these directly into the function argument below?
         is_combined_view = args.combined_view
         if is_combined_view: is_split_view = False    # Force to use combined view if specified
         reveal_all_lights = args.reveal_all_lights
         has_error = sort_logic.RelocateSortObjects(playdo, dict_sortval, is_split_view, is_combined_view, reveal_all_lights)
+
+    # Milestone 5 - Update sort objects in BG Parallax
+    sort_logic.SortBGParallax(playdo)
 
     user_input = input(f"Commit changes to \'{level_name}\'? (Y/N) ")
     if user_input[0].lower() == 'y': playdo.Write(make_auto_backup=True)

--- a/cli_sort.py
+++ b/cli_sort.py
@@ -13,7 +13,9 @@ USAGE EXAMPLE:
     python cli_sort.py sf1 --v 0 --reveal_all_lights
     python cli_sort.py sf1 --v 0 -- rewind
 
-    clear; python cli_sort.py w01_BEFORE --v 2
+    cd /Users/Jimmy/20-GitHub/StarTools
+    clear; python cli_sort.py w01_parallax_test --v 2
+    clear; python cli_sort.py w_test --v 2
 '''
 import argparse
 import logic.common.file_utils as file_utils

--- a/cli_test.py
+++ b/cli_test.py
@@ -3,7 +3,8 @@
     
 USAGE EXAMPLE:
     cd /Users/Jimmy/20-GitHub/StarTools
-    python cli_test.py z01 --v 2
+    clear; python cli_test.py z01 --v 2
+    clear; python cli_test.py w01_BEFORE --v 2
 
 '''
 import argparse
@@ -12,6 +13,7 @@ import logic.common.backup_utils as backup_utils
 import logic.common.log_utils as log
 import logic.common.level_playdo as play
 import logic.pattern.pattern_matcher as PM
+import logic.standalone.sort2_setter as logic
 
 #--------------------------------------------------#
 '''Variables'''
@@ -42,10 +44,11 @@ def main():
 
     # Main Logic - ...
 #    do_the_thing()
+    logic.SortBGParallax(playdo)
 
     # Flush changes to File!
     playdo.Write(make_auto_backup=True)
-    backup_utils.RestoreBackup(playdo)
+#    backup_utils.RestoreBackup(playdo)    # This immediately revert the changes
 
 
 

--- a/cli_test.py
+++ b/cli_test.py
@@ -5,6 +5,7 @@ USAGE EXAMPLE:
     cd /Users/Jimmy/20-GitHub/StarTools
     clear; python cli_test.py z01 --v 2
     clear; python cli_test.py w01_BEFORE --v 2
+    clear; python cli_test.py w01_parallax_test --v 2
 
 '''
 import argparse
@@ -47,7 +48,7 @@ def main():
     logic.SortBGParallax(playdo)
 
     # Flush changes to File!
-    playdo.Write(make_auto_backup=True)
+#    playdo.Write(make_auto_backup=True)
 #    backup_utils.RestoreBackup(playdo)    # This immediately revert the changes
 
 

--- a/logic/common/level_playdo.py
+++ b/logic/common/level_playdo.py
@@ -147,13 +147,15 @@ class LevelPlayDo():
             log.Extra(f'-- level_playdo.py : objectgroup found : {len(list_objectgroup)}')
         return list_objectgroup
 
-    def GetAllObjects(self, ignore_inactive_objectgroup = True):
+    def GetAllObjects(self, ignore_inactive_objectgroup = True, include_meta_object = False):
         '''Fetches all XML objects and return them as an array'''
         list_object = []
         for objectgroup in self.GetAllObjectgroup():
             # Ignore object layers if not read by level
             layer_name = objectgroup.get('name')
-            if (ignore_inactive_objectgroup) and not (layer_name.startswith('objects') or layer_name.startswith('collisions')): continue
+            skip_layer_inactive = (ignore_inactive_objectgroup) and not (layer_name.startswith('objects') or layer_name.startswith('collisions'))
+            skip_layer_meta     = (include_meta_object)         and not (layer_name == 'meta')
+            if skip_layer_inactive and skip_layer_meta: continue
             # Append to list
             for obj in objectgroup: list_object.append(obj)
         return list_object

--- a/logic/standalone/sort2_setter.py
+++ b/logic/standalone/sort2_setter.py
@@ -49,6 +49,13 @@ sort_exclusion_property   = "do_not_sort"     # Object has property
 sort_exclusion_name       = "do_not_sort"     # Layer has substring
 split_view_exclusion_name = ["no_split_view"] # Layer has substring
 
+# Sort keyword
+sort1_keyword1 = '_sort'
+sort1_keyword2 = '_sort1'
+sort2_keyword  = '_sort2'
+
+#sort1_keyword2 = '_sort2'  # NOTE debugging
+
 
 
 #--------------------------------------------------#
@@ -164,7 +171,7 @@ def RenameTilelayer(playdo):
     '''
     This renames all tilelayers to fit the current standard
      Error Check 1 : Level has more than 9 tilelayers
-     Error Check 2 : Level has more than 6 FG, or 6 BG tilelayers
+     Error Check 2 : Level has more than 6 FG tilelayers, or 6 BG tilelayers
      Error Check 3 : Level has another BG layer above bg_owp
      Error Check 4 : A layer contains a _sort property
      Error Check 5 : Level does not have a bg_owp layer
@@ -400,13 +407,15 @@ def _UpdateTileLayerReferencesInObject(obj, list_name_bef_aft, count, playdo):
 def _RenameLayerInProperty(curr_property, list_name_bef_aft):
     '''Adjust the property value if it contains a tilelayer name that needs to be renamed'''
     # Scan through all properties
+#    print(list_name_bef_aft)
     old_value = curr_property.get('value')
     new_value = old_value
-    for tuple in list_name_bef_aft:
-        name_bef = tuple[0].replace('/fx','')
-        name_aft = tuple[1].replace('/fx','')
-        if name_bef in old_value:
-            new_value = new_value.replace(name_bef, name_aft)
+    if old_value != None:
+        for tuple in list_name_bef_aft:
+            name_bef = tuple[0].replace('/fx','')
+            name_aft = tuple[1].replace('/fx','')
+            if name_bef in old_value:
+                new_value = new_value.replace(name_bef, name_aft)
     return new_value    # Property value is unchanged if it doesn't contain any of the tilelayer name before-change
 
 
@@ -578,6 +587,7 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
         sort_order = int(old_sort.split('/')[1]) # int portion
         if sort_layer == 'fg_tiles': sort_order += DICT_KEY_ADDON_FG_SORT
         elif sort_layer == 'bg_tiles': sort_order += 0    # Do nothing
+        elif sort_layer == 'fg_parallax' or sort_layer == 'bg_parallax': continue    # Will be resorted later
         else:
             obj_name = obj.get('name')
             parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
@@ -649,6 +659,8 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
             else: sort2_value += 'bg'
             sort2_value += '_tiles/' + str(sortval)
 
+            # TODO Deprecate
+            '''
             obj_name = obj.get('name')
             old_sort  = tiled_utils.GetPropertyFromObject(obj, 'sort')
             old_sort += tiled_utils.GetPropertyFromObject(obj, '_sort')
@@ -663,6 +675,8 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
                 if mat_indicator == '': mat_indicator =  '    (---)'
                 else:                   mat_indicator = f'    ({mat_indicator})'
             log.Must(f'      {_IndentBack(obj_name, max_name_len+2, True)} {change_indicator} {old_sort} -> {sort2_value}{mat_indicator}')
+            '''
+            count_sort_changed = _PrintSortChange(obj, sort2_value, is_sorting_by_mat, max_name_len, count_sort_changed)
 
             tiled_utils.SetPropertyOnObject(obj, '_sort2', sort2_value)
 
@@ -1106,6 +1120,145 @@ def _ChangeObjectType(obj, type_str):
 
 
 
+#-----------------------------------#
+#---------- [Milestone 5] ----------#
+
+def SortBGParallax(playdo):
+    '''TODO
+     Simplified version of existing methods for sorting FG & BG objects
+    '''
+    log.Must(f"  Procedure 5 - Relocating BG Parallax objects")
+
+    # TODO detect
+#    is_using_sort1 = True
+
+    # Filter only the objects needed
+    list_meta_parallax_tuple = []    # ( <obj>, <property value> )
+    list_all_objects = playdo.GetAllObjects(True, True)
+    dict_all_sortval = {}
+    for obj in list_all_objects:
+        # Skip object if not using sort1 standard
+        old_sort = tiled_utils.GetPropertyFromObject(obj, sort1_keyword1, True)
+        if old_sort == None: old_sort = tiled_utils.GetPropertyFromObject(obj, sort1_keyword2, True)
+        if old_sort == None: old_sort = tiled_utils.GetPropertyFromObject(obj, sort2_keyword,  True)
+#        print(old_sort)
+        if old_sort == None: continue
+
+        # Skip object if the parsed sort value isn't for BG Parallax
+        sort_layer = old_sort.split('/')[0]      # string portion
+        sort_order = int(old_sort.split('/')[1]) # int portion
+#        print(sort_layer)
+        if sort_layer != 'bg_parallax': continue
+#        sort_order = 20 # NOTE debug
+
+        # Append to dictionary, to be reordered later
+#        list_parallax_tuple.append( (obj, old_sort) )
+        if obj.get('name') == 'env_art':
+            list_meta_parallax_tuple.append( (obj, sort_order) )
+        else:
+            if not sort_order in dict_all_sortval: dict_all_sortval[sort_order] = []
+            dict_all_sortval[sort_order].append(obj)
+
+    # Sort by key
+    dict_all_sortval = dict(sorted(dict_all_sortval.items()))
+
+    # TODO update comment
+    # Map all objects to the 2nd dictionary into their respective buckets
+    #  Key is the tuple storing unique sort-group in "buckets", e.g. "fg_tiles/15" -> is FG & 2nd layer -> (True, 2)
+    #  Value is the array of objects, which all belong to the same "bucket"
+    max_name_len = 1
+    dict_all_buckets = {}
+    # Add the meta objects to the dictionary first to make sure it's the first element
+    for tuple in list_meta_parallax_tuple:
+        obj   = tuple[0]
+        value = tuple[1]
+        new_layer_num = _GetLayerNumberOfParallax(value, list_meta_parallax_tuple)
+        curr_key = (False, new_layer_num)
+        if not curr_key in dict_all_buckets:
+            dict_all_buckets[curr_key] = []
+        dict_all_buckets[curr_key].append(obj)
+
+    for key, value in dict_all_sortval.items():
+        # Usually has to always create new bucket for the dict, adding if-statement as fail-safe
+        new_layer_num = _GetLayerNumberOfParallax(key, list_meta_parallax_tuple)
+        curr_key = (False, new_layer_num)
+        if not curr_key in dict_all_buckets:
+            dict_all_buckets[curr_key] = []
+#        print(f'Key : {key}     Num : {new_layer_num}')
+
+        # Append to new bucket
+        for obj in value:
+            dict_all_buckets[curr_key].append(obj)
+            obj_name = obj.get('name')
+            if max_name_len < len(obj_name): max_name_len = len(obj_name)
+
+
+    # Assign new sort values in properties
+    for key, value in dict_all_buckets.items():
+        is_fg    = key[0] # Unneeded, since it's always False
+        sortval  = key[1]
+        list_obj = value
+
+        sortval = sortval * 5000
+        for obj in list_obj:
+            sortval += 10
+
+            sort2_value = ''
+            if is_fg: sort2_value += 'fg'
+            else: sort2_value += 'bg'
+            sort2_value += '_parallax/' + str(sortval)
+
+            _PrintSortChange(obj, sort2_value, False, max_name_len)
+            tiled_utils.RemovePropertyFromObject(obj, sort1_keyword1)
+            tiled_utils.RemovePropertyFromObject(obj, sort1_keyword2)
+            tiled_utils.SetPropertyOnObject(obj, sort2_keyword, sort2_value)
+
+            # This should never happen
+            if sortval > 32000:
+                obj_name = obj.get('name')
+                log.Must(f'        WARNING! \'{obj_name}\' has new sort exceeding limit : \'{sortval}\'')
+        log.Must("")
+
+
+
+
+
+
+    # NOTE DEBUG Print
+#    print(list_parallax_tuple)
+    if not True:
+        print(list_parallax_tuple)
+#        for tuple in list_parallax_tuple: print(tuple[0].get('name') + '\t' + tuple[1])
+        print(dict_all_sortval)
+        print(dict_all_buckets)
+    return
+
+def _GetLayerNumberOfParallax(sort_num, list_parallax_tuple):
+    '''TODO
+     Return N in "above the N-th layer"
+    '''
+
+    # Get the list of parallax values from the objects, then sort in ascending order
+    list_parallax_values = []
+    for tuple in list_parallax_tuple:
+#        sort_tuple = tuple[1].split('/')
+        sort_value = tuple[1]
+        list_parallax_values.append(sort_value)
+    list_parallax_values.sort(reverse=True)
+#    print(list_parallax_values)
+
+    # Check which layer it's in
+    layer_num = -1
+    for index, value in enumerate(list_parallax_values):
+        if sort_num >= value:
+            layer_num = len(list_parallax_values) - index
+            break
+    return layer_num
+
+
+
+
+
 #--------------------------------------------------#
 '''Other Utility'''
 
@@ -1117,9 +1270,22 @@ def _IndentBack(string, max_len, add_quotation = False):
         string += (max_len - len(string)) * ' '
     return string
 
-
-
-
+def _PrintSortChange(obj, sort2_value, is_sorting_by_mat, max_name_len, count_sort_changed = 0):
+    obj_name = obj.get('name')
+    old_sort  = tiled_utils.GetPropertyFromObject(obj, 'sort')
+    old_sort += tiled_utils.GetPropertyFromObject(obj, '_sort')
+    old_sort += tiled_utils.GetPropertyFromObject(obj, '_sort2')
+    change_indicator = ' '
+    if old_sort != sort2_value:
+        change_indicator = '*'
+        count_sort_changed += 1
+    mat_indicator = ''
+    if is_sorting_by_mat:
+        mat_indicator = tiled_utils.GetPropertyFromObject(obj, MAT_PROPERTY_NAME)
+        if mat_indicator == '': mat_indicator =  '    (---)'
+        else:                   mat_indicator = f'    ({mat_indicator})'
+    log.Must(f'      {_IndentBack(obj_name, max_name_len+2, True)} {change_indicator} {old_sort} -> {sort2_value}{mat_indicator}')
+    return count_sort_changed
 
 
 

--- a/logic/standalone/sort2_setter.py
+++ b/logic/standalone/sort2_setter.py
@@ -50,11 +50,14 @@ sort_exclusion_name       = "do_not_sort"     # Layer has substring
 split_view_exclusion_name = ["no_split_view"] # Layer has substring
 
 # Sort keyword
-sort1_keyword1 = '_sort'
-sort1_keyword2 = '_sort1'
+sort1_keyword1 = 'sort'     # TODO replace previous procedures with this 2
+sort1_keyword2 = '_sort'
+#sort1_keyword2 = '_sort2'  # NOTE debugging
 sort2_keyword  = '_sort2'
 
-#sort1_keyword2 = '_sort2'  # NOTE debugging
+parallax_obj_keyword   = 'env_art'
+parallax_layer_keyword = 'bg_parallax'
+
 
 
 
@@ -130,17 +133,27 @@ def ErrorCheckSortOrder(playdo):
         log.Must(f'    {num_group1} objects are explicitly using sort1')
         log.Must(f'    {num_group2} objects are explicitly using sort2\n')
         count = 0
-        if num_group1 < num_group2:
-            log.Must(f'    Offending sort1 objects: ')
+        if log.GetVerbosityLevel() == 2 or num_group1 <= num_group2:
+            log.Must(f'    Offending sort1 objects: (\'sort\')')
             for obj in list_old_sort_objects:
                 obj_name = obj.get('name')
                 parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
-                sort0_value = tiled_utils.GetPropertyFromObject(obj, 'sort')
-                sort1_value = tiled_utils.GetPropertyFromObject(obj, '_sort')
-                log.Must(f'      ({count+1}) \'{obj_name}\' at \'{parent_name}\' : \'{sort0_value}\', \'{sort1_value}\'')
+                sort1_value = tiled_utils.GetPropertyFromObject(obj, 'sort')
+                if sort1_value == '': continue
+                log.Must(f'      ({count+1}) \'{obj_name}\' at \'{parent_name}\' : \'{sort1_value}\'')
                 count += 1
-        else:
-            log.Must(f'    Offending sort2 objects: ')
+            log.Extra('')
+            log.Must(f'    Offending sort1 objects: (\'_sort\')')
+            for obj in list_old_sort_objects:
+                obj_name = obj.get('name')
+                parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
+                sort1_value = tiled_utils.GetPropertyFromObject(obj, '_sort')
+                if sort1_value == '': continue
+                log.Must(f'      ({count+1}) \'{obj_name}\' at \'{parent_name}\' : \'{sort1_value}\'')
+                count += 1
+            log.Extra('')
+        if log.GetVerbosityLevel() == 2 or num_group1 >= num_group2:
+            log.Must(f'    Offending sort2 objects: (\'_sort2\')')
             for obj in list_new_sort_objects:
                 obj_name = obj.get('name')
                 parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
@@ -449,6 +462,13 @@ def ConvertSortValueStandard(playdo, bg_owp_prev_index, fg_anchor_prev_index, ma
         if sort_exclusion_name in tiled_utils.GetParentObject(obj, playdo).get('name'): continue
         if tiled_utils.GetPropertyFromObject(obj, sort_exclusion_property, True) != None: continue
 
+        # Ignore if is 'env_art' objects, or value starts bg_parallax? TODO check if it's okay
+        if obj_name == parallax_obj_keyword: continue
+        temp_value  = tiled_utils.GetPropertyFromObject(obj, sort1_keyword1)
+        temp_value += tiled_utils.GetPropertyFromObject(obj, sort1_keyword2)
+        temp_value += tiled_utils.GetPropertyFromObject(obj, sort2_keyword)
+        if temp_value.startswith(parallax_layer_keyword): continue
+
         # Is in resort group?
         if obj_name in LIST_OBJ_RESORT_NAME:
             objs_to_resort.append(obj)
@@ -515,8 +535,9 @@ def _LogObjectsToResort(objs_to_resort):
     '''This function is purely for logging - Shows how many of each objects have redundant _sort'''
     if len(objs_to_resort) == 0: return
 
-    log.Must(f"{len(objs_to_resort)} objects no longer require a sort property and have graduated to a")
-    log.Must( " permanent unique sort order; their sort property will be removed.")
+    log.Must("")
+    log.Must(f"      {len(objs_to_resort)} objects no longer require a sort property and have graduated to a")
+    log.Must( "       permanent unique sort order; their sort property will be removed.")
 
     # Key is object name; Value is number of objects with for each name
     dict_by_name = {}
@@ -524,6 +545,7 @@ def _LogObjectsToResort(objs_to_resort):
         obj_name = obj.get('name')
         if not obj_name in dict_by_name: dict_by_name[obj_name] = 0
         dict_by_name[obj_name] += 1
+        log.Extra(f"         \"{obj_name}\"")
 
     # Log the details
     for key, value in dict_by_name.items():
@@ -583,11 +605,15 @@ def _Resort_NormalObjects(objs_to_resort, playdo, bg_owp_prev_index, fg_anchor_p
         # Create the "key" that allows sorting items by values
         #  e.g. As string, it has trouble handling single-digit numbers
         # old_sort example : "fg_tiles/13"
+#        if len(old_sort.split('/')) >= 2:
         sort_layer = old_sort.split('/')[0]      # string portion
         sort_order = int(old_sort.split('/')[1]) # int portion
+#        else:    # Crash prevention? TODO ask if it's allowed
+#            sort_layer = parallax_layer_keyword
+#            sort_order = int(old_sort) # int portion
         if sort_layer == 'fg_tiles': sort_order += DICT_KEY_ADDON_FG_SORT
         elif sort_layer == 'bg_tiles': sort_order += 0    # Do nothing
-        elif sort_layer == 'fg_parallax' or sort_layer == 'bg_parallax': continue    # Will be resorted later
+        elif sort_layer == 'fg_parallax' or sort_layer == parallax_layer_keyword: continue    # Will be resorted later
         else:
             obj_name = obj.get('name')
             parent_name = tiled_utils.GetParentObject(obj, playdo).get('name')
@@ -1137,23 +1163,26 @@ def SortBGParallax(playdo):
     list_all_objects = playdo.GetAllObjects(True, True)
     dict_all_sortval = {}
     for obj in list_all_objects:
-        # Skip object if not using sort1 standard
-        old_sort = tiled_utils.GetPropertyFromObject(obj, sort1_keyword1, True)
-        if old_sort == None: old_sort = tiled_utils.GetPropertyFromObject(obj, sort1_keyword2, True)
-        if old_sort == None: old_sort = tiled_utils.GetPropertyFromObject(obj, sort2_keyword,  True)
-#        print(old_sort)
-        if old_sort == None: continue
+        # Skip object if doesn't have sort property
+        old_sort  = tiled_utils.GetPropertyFromObject(obj, sort1_keyword1)
+        old_sort += tiled_utils.GetPropertyFromObject(obj, sort1_keyword2)
+        old_sort += tiled_utils.GetPropertyFromObject(obj, sort2_keyword)
+        if old_sort == '': continue
 
         # Skip object if the parsed sort value isn't for BG Parallax
-        sort_layer = old_sort.split('/')[0]      # string portion
-        sort_order = int(old_sort.split('/')[1]) # int portion
+        if len(old_sort.split('/')) >= 2:
+            sort_layer = old_sort.split('/')[0]      # string portion
+            sort_order = int(old_sort.split('/')[1]) # int portion
+            if sort_layer != parallax_layer_keyword: continue
+        else:    # Sometimes 'env_art' object doesn't have it specified. Crash prevention? TODO ask if it's allowed
+            if obj.get('name') != parallax_obj_keyword: continue
+            sort_order = int(old_sort) # int portion
 #        print(sort_layer)
-        if sort_layer != 'bg_parallax': continue
 #        sort_order = 20 # NOTE debug
 
         # Append to dictionary, to be reordered later
 #        list_parallax_tuple.append( (obj, old_sort) )
-        if obj.get('name') == 'env_art':
+        if obj.get('name') == parallax_obj_keyword:
             list_meta_parallax_tuple.append( (obj, sort_order) )
         else:
             if not sort_order in dict_all_sortval: dict_all_sortval[sort_order] = []
@@ -1201,8 +1230,6 @@ def SortBGParallax(playdo):
 
         sortval = sortval * 5000
         for obj in list_obj:
-            sortval += 10
-
             sort2_value = ''
             if is_fg: sort2_value += 'fg'
             else: sort2_value += 'bg'
@@ -1212,6 +1239,8 @@ def SortBGParallax(playdo):
             tiled_utils.RemovePropertyFromObject(obj, sort1_keyword1)
             tiled_utils.RemovePropertyFromObject(obj, sort1_keyword2)
             tiled_utils.SetPropertyOnObject(obj, sort2_keyword, sort2_value)
+
+            sortval += 10
 
             # This should never happen
             if sortval > 32000:


### PR DESCRIPTION
Main Edits:
 - `cli_sort`, added comments and temporary commands
 - `cli_test`, temporary testing tool
 - logic, functions added for the new procedure that sort `bg_parallax` objects
 - logic, fixed crash when property has empty value
 - logic, exclude objects with `fg_`/`bg_parallax` during normal sort process to avoid crash
 - logic, separate the print function
 - `playdo`, can grab meta objects now